### PR TITLE
add order_by("?") for random ordering (#11)

### DIFF
--- a/crates/oxyde-query/src/builder/select.rs
+++ b/crates/oxyde-query/src/builder/select.rs
@@ -107,6 +107,10 @@ fn build_select_statement(ir: &QueryIR) -> Result<SelectStatement> {
     // ORDER BY, LIMIT, OFFSET — placed after UNION by sea-query
     if let Some(order_by) = &ir.order_by {
         for (field, direction) in order_by {
+            if field == "?" {
+                query.order_by_expr(Func::random().into(), Order::Asc);
+                continue;
+            }
             let order = match direction.to_uppercase().as_str() {
                 "ASC" => Order::Asc,
                 "DESC" => Order::Desc,

--- a/crates/oxyde-query/src/lib.rs
+++ b/crates/oxyde-query/src/lib.rs
@@ -437,6 +437,51 @@ mod tests {
     }
 
     #[test]
+    fn test_order_by_random() {
+        let ir = QueryIR {
+            table: "authors".into(),
+            order_by: Some(vec![("?".into(), "RANDOM".into())]),
+            ..Default::default()
+        };
+
+        let (sqlite_sql, _) = build_sql(&ir, Dialect::Sqlite).unwrap();
+        assert!(
+            sqlite_sql.contains("ORDER BY RANDOM()"),
+            "SQLite: expected ORDER BY RANDOM(), got: {sqlite_sql}"
+        );
+
+        let (pg_sql, _) = build_sql(&ir, Dialect::Postgres).unwrap();
+        assert!(
+            pg_sql.contains("ORDER BY RANDOM()"),
+            "Postgres: expected ORDER BY RANDOM(), got: {pg_sql}"
+        );
+
+        let (mysql_sql, _) = build_sql(&ir, Dialect::Mysql).unwrap();
+        assert!(
+            mysql_sql.contains("ORDER BY RAND()"),
+            "MySQL: expected ORDER BY RAND(), got: {mysql_sql}"
+        );
+    }
+
+    #[test]
+    fn test_order_by_random_mixed_with_field() {
+        let ir = QueryIR {
+            table: "authors".into(),
+            order_by: Some(vec![
+                ("name".into(), "ASC".into()),
+                ("?".into(), "RANDOM".into()),
+            ]),
+            ..Default::default()
+        };
+
+        let (sql, _) = build_sql(&ir, Dialect::Sqlite).unwrap();
+        assert!(
+            sql.contains("ORDER BY") && sql.contains("\"name\" ASC") && sql.contains("RANDOM()"),
+            "expected mixed ORDER BY with field and RANDOM(), got: {sql}"
+        );
+    }
+
+    #[test]
     fn test_union_all_generates_correct_sql() {
         let union_ir = QueryIR {
             table: "posts".into(),

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -47,7 +47,7 @@ Complete API reference.
 <tr><th colspan="4">Query Builder</th></tr>
 <tr><td><code>filter()</code></td><td><code>.filter(is_active=True, age__gte=18)</code></td><td><code>Query</code></td><td>WHERE conditions</td></tr>
 <tr><td><code>exclude()</code></td><td><code>.exclude(status="banned")</code></td><td><code>Query</code></td><td>WHERE NOT</td></tr>
-<tr><td><code>order_by()</code></td><td><code>.order_by("-created_at")</code></td><td><code>Query</code></td><td>ORDER BY</td></tr>
+<tr><td><code>order_by()</code></td><td><code>.order_by("-created_at")</code> / <code>.order_by("?")</code></td><td><code>Query</code></td><td>ORDER BY (use <code>"?"</code> for random)</td></tr>
 <tr><td><code>limit()</code></td><td><code>.limit(10)</code></td><td><code>Query</code></td><td>LIMIT</td></tr>
 <tr><td><code>offset()</code></td><td><code>.offset(20)</code></td><td><code>Query</code></td><td>OFFSET</td></tr>
 <tr><td><code>prefetch()</code></td><td><code>.prefetch("posts")</code></td><td><code>Query</code></td><td>Load reverse FK/M2M</td></tr>

--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -134,6 +134,9 @@ users = await User.objects.order_by("-created_at").all()
 
 # Multiple columns
 users = await User.objects.order_by("status", "-created_at").all()
+
+# Random order
+users = await User.objects.order_by("?").all()
 ```
 
 ### Pagination

--- a/python/oxyde/queries/mixins/pagination.py
+++ b/python/oxyde/queries/mixins/pagination.py
@@ -42,10 +42,12 @@ class PaginationMixin:
         return clone
 
     def order_by(self, *fields: str) -> Self:
-        """Set ORDER BY fields."""
+        """Set ORDER BY fields. Use "?" for random ordering (ORDER BY RANDOM())."""
         clone = self._clone()
         for field in fields:
-            if field.startswith("-"):
+            if field == "?":
+                clone._order_by_fields.append(("?", "RANDOM"))
+            elif field.startswith("-"):
                 clone._order_by_fields.append((field[1:], "DESC"))
             else:
                 clone._order_by_fields.append((field, "ASC"))

--- a/python/oxyde/queries/select.py
+++ b/python/oxyde/queries/select.py
@@ -237,7 +237,7 @@ class Query(
         # Convert field names to db_columns for Rust (Rust operates on columns only)
         db_columns = [self._column_for_field(f) for f in fields]
         order_by = [
-            (self._column_for_field(field), direction)
+            (field if field == "?" else self._column_for_field(field), direction)
             for field, direction in self._order_by_fields
         ]
 

--- a/python/oxyde/tests/integration/test_pagination.py
+++ b/python/oxyde/tests/integration/test_pagination.py
@@ -57,6 +57,19 @@ class TestOrderBy:
         assert names == ["Charlie", "Bob", "Alice"]
 
 
+class TestOrderByRandom:
+    @pytest.mark.asyncio
+    async def test_order_by_random_returns_all_records(self, db):
+        authors = await Author.objects.order_by("?").all(using=db.name)
+        assert len(authors) == 3
+        assert {a.name for a in authors} == {"Alice", "Bob", "Charlie"}
+
+    @pytest.mark.asyncio
+    async def test_order_by_random_combined_with_limit(self, db):
+        authors = await Author.objects.order_by("?").limit(2).all(using=db.name)
+        assert len(authors) == 2
+
+
 class TestDistinct:
     @pytest.mark.asyncio
     async def test_distinct(self, db):


### PR DESCRIPTION
Adds support for `order_by("?")`, mirroring Django ORM's random ordering shorthand.

Maps to `ORDER BY RANDOM()` on PostgreSQL and SQLite, and `ORDER BY RAND()` on MySQL.

## Changes
- `order_by("?")` recognised in `PaginationMixin` and passed through the IR as `("?", "RANDOM")`
- Column mapping in `select.py` skips field resolution for `"?"`
- Rust query builder calls `Func::random()` via `order_by_expr` when it sees `"?"`

## Tests
- Rust unit tests asserting correct SQL for all three dialects
- Integration tests covering random ordering and random + limit across SQLite, PostgreSQL, and MySQL

Closes #11