### PR TITLE
Preserve max_length and decimal constraints in alter_column replay

### DIFF
--- a/python/oxyde/migrations/context.py
+++ b/python/oxyde/migrations/context.py
@@ -246,6 +246,12 @@ class MigrationContext:
             new_field["default"] = changes["default"]
         if "unique" in changes:
             new_field["unique"] = changes["unique"]
+        if "max_length" in changes:
+            new_field["max_length"] = changes["max_length"]
+        if "max_digits" in changes:
+            new_field["max_digits"] = changes["max_digits"]
+        if "decimal_places" in changes:
+            new_field["decimal_places"] = changes["decimal_places"]
 
         # Build Rust-compatible operation
         op = {

--- a/python/oxyde/migrations/generator.py
+++ b/python/oxyde/migrations/generator.py
@@ -132,6 +132,12 @@ def _operation_to_python(op: dict[str, Any], indent: str = "    ") -> str:
                 changes["default"] = new_field.get("default")
             if old_field.get("unique") != new_field.get("unique"):
                 changes["unique"] = new_field["unique"]
+            if old_field.get("max_length") != new_field.get("max_length"):
+                changes["max_length"] = new_field.get("max_length")
+            if old_field.get("max_digits") != new_field.get("max_digits"):
+                changes["max_digits"] = new_field.get("max_digits")
+            if old_field.get("decimal_places") != new_field.get("decimal_places"):
+                changes["decimal_places"] = new_field.get("decimal_places")
         else:
             # Python format - use as-is
             column = op["column"]

--- a/python/oxyde/migrations/replay.py
+++ b/python/oxyde/migrations/replay.py
@@ -94,6 +94,12 @@ class SchemaState:
                             field["default"] = changes["default"]
                         if "unique" in changes:
                             field["unique"] = changes["unique"]
+                        if "max_length" in changes:
+                            field["max_length"] = changes["max_length"]
+                        if "max_digits" in changes:
+                            field["max_digits"] = changes["max_digits"]
+                        if "decimal_places" in changes:
+                            field["decimal_places"] = changes["decimal_places"]
                         break
 
         elif op_type == "create_index":

--- a/python/oxyde/tests/unit/test_migrations_detection.py
+++ b/python/oxyde/tests/unit/test_migrations_detection.py
@@ -8,6 +8,9 @@ from uuid import UUID
 import pytest
 
 from oxyde import Field, Model
+from oxyde.migrations.context import MigrationContext
+from oxyde.migrations.generator import _operation_to_python
+from oxyde.migrations.replay import SchemaState
 from oxyde.models.registry import registered_tables
 
 
@@ -377,6 +380,96 @@ class TestSchemaDiff:
         indexed_meta = IndexedModel._db_meta.field_metadata["email"]
 
         assert unindexed_meta.index != indexed_meta.index
+
+    def test_detect_alter_max_length(self):
+        """Test detecting max_length changes in generated alter_column migrations."""
+        op = {
+            "type": "alter_column",
+            "table": "widgets",
+            "old_field": {
+                "name": "code",
+                "max_length": 64,
+            },
+            "new_field": {
+                "name": "code",
+                "max_length": 128,
+            },
+        }
+
+        rendered = _operation_to_python(op)
+
+        assert '    ctx.alter_column("widgets", "code", max_length=128)' == rendered
+
+    def test_detect_alter_max_digits(self):
+        """Test detecting max_digits changes during alter_column replay."""
+        state = SchemaState()
+        state.tables["widgets"] = {
+            "name": "widgets",
+            "fields": [
+                {
+                    "name": "price",
+                    "max_digits": 10,
+                }
+            ],
+        }
+
+        state.apply_operation(
+            {
+                "type": "alter_column",
+                "table": "widgets",
+                "column": "price",
+                "changes": {"max_digits": 12},
+            }
+        )
+
+        field = state.tables["widgets"]["fields"][0]
+        assert field["max_digits"] == 12
+
+    def test_detect_alter_decimal_places(self):
+        """Test detecting decimal_places changes during alter_column replay."""
+        state = SchemaState()
+        state.tables["widgets"] = {
+            "name": "widgets",
+            "fields": [
+                {
+                    "name": "price",
+                    "decimal_places": 2,
+                }
+            ],
+        }
+
+        state.apply_operation(
+            {
+                "type": "alter_column",
+                "table": "widgets",
+                "column": "price",
+                "changes": {"decimal_places": 4},
+            }
+        )
+
+        field = state.tables["widgets"]["fields"][0]
+        assert field["decimal_places"] == 4
+
+    def test_detect_alter_collect_replay(self):
+        """Test detecting collected alter_column changes during replay."""
+        ctx = MigrationContext(mode="collect")
+        ctx.alter_column("widgets", "name", max_length=255)
+
+        state = SchemaState()
+        state.tables["widgets"] = {
+            "name": "widgets",
+            "fields": [
+                {
+                    "name": "name",
+                    "max_length": 100,
+                }
+            ],
+        }
+
+        for op in ctx.get_collected_operations():
+            state.apply_operation(op)
+
+        assert state.tables["widgets"]["fields"][0]["max_length"] == 255
 
 
 class TestModelMetaOptions:


### PR DESCRIPTION
This PR preserves constraint-related `alter_column` changes during migration generation and replay.

  Specifically, it keeps these fields from being dropped when migrations are generated or replayed:

  - `max_length`
  - `max_digits`
  - `decimal_places`

  It also adds focused regression tests for those cases.

  ## Problem

  `makemigrations` could repeatedly generate the same `alter_column(...)` operations for constraint-only field changes because those constraint fields were not preserved
  through the Python migration round-trip.

  That meant Oxyde could detect the change, write the migration, and then lose part of that change when replaying migrations to rebuild schema state.

  ## Changes

  - preserve `max_length`, `max_digits`, and `decimal_places` in migration generation
  - preserve the same fields in migration replay
  - preserve the same fields when building `new_field` for `alter_column`
  - add targeted tests in `test_migrations_detection.py`

  ## Scope

  This fixes constraint-field round-tripping for `alter_column`.

  It does **not** attempt to fix other unrelated repeated `alter_column` diffs.

  ## Testing

  oxyde/tests/unit/test_migrations_detection.py