### PR TITLE
Overhauled typing and stub generation

### DIFF
--- a/python/oxyde/codegen/stub_generator.py
+++ b/python/oxyde/codegen/stub_generator.py
@@ -21,6 +21,17 @@ from oxyde.models.lookups import (
 )
 from oxyde.models.registry import registered_tables
 
+_CREATE_RESERVED_PARAMS = frozenset({"instance", "client", "using"})
+
+# Safe aliases used in __init__ signatures to avoid field-name / type-name conflicts (e.g. a field
+# named "datetime" annotated as "datetime | None" would shadow the imported datetime class inside
+# the class body).
+_SAFE_TYPE_ALIASES: dict[str, str] = {
+    "datetime": "_Datetime",
+    "date": "_Date",
+    "time": "_Time",
+}
+
 
 def _get_python_type_name(python_type: Any) -> str:
     """Get string representation of Python type for stub file."""
@@ -125,37 +136,53 @@ def _get_field_info(model_class: type[Model]) -> dict[str, tuple[Any, bool]]:
     return result
 
 
-def _generate_filter_params(model_class: type[Model]) -> str:
-    """Generate filter method parameters with all lookups."""
+def _append_scalar_lookups(lines: list[str], prefix: str, python_type: Any) -> None:
+    """Append exact-match + all lookup suffix params for a scalar field."""
+    type_name = _get_python_type_name(python_type)
+    lines.append(f"        {prefix}: {type_name} | None = None,")
+    for lookup in _get_lookups_for_type(python_type):
+        if lookup == "in":
+            lookup_type = f"list[{type_name}] | None"
+        elif lookup == "between":
+            lookup_type = f"tuple[{type_name}, {type_name}] | None"
+        elif lookup == "isnull":
+            lookup_type = "bool | None"
+        elif lookup in DATE_PART_LOOKUPS:
+            lookup_type = "int | None"
+        else:
+            lookup_type = f"{type_name} | None"
+        lines.append(f"        {prefix}__{lookup}: {lookup_type} = None,")
+
+
+def _generate_filter_params(model_class: type[Model], prefix: str = "") -> list[str]:
+    """Generate filter method parameters with all lookups, including FK traversal."""
     lines = []
     field_info = _get_field_info(model_class)
 
     for field_name, (python_type, _is_pk) in sorted(field_info.items()):
-        type_name = _get_python_type_name(python_type)
+        current_field = f"{prefix}__{field_name}" if prefix else field_name
 
-        # Exact match (field without lookup)
-        lines.append(f"        {field_name}: {type_name} | None = None,")
+        # FK field — emit isnull for relation itself, recurse into related model to emit type-specific filters
+        if isinstance(python_type, type) and issubclass(python_type, Model):
+            type_name = _get_python_type_name(python_type)
+            lines.append(f"        {current_field}: {type_name} | None = None,")
+            lines.append(f"        {current_field}__isnull: bool | None = None,")
 
-        # Add all lookups for this type
-        lookups = _get_lookups_for_type(python_type)
-        for lookup in lookups:
-            lookup_field = f"{field_name}__{lookup}"
+            related_fields = _get_field_info(python_type)
+            for related_name, (related_type, _) in sorted(related_fields.items()):
+                if isinstance(related_type, type) and issubclass(related_type, Model):
+                    nested_prefix = f"{current_field}__{related_name}"
+                    lines.extend(
+                        _generate_filter_params(related_type, prefix=nested_prefix)
+                    )
+                else:
+                    _append_scalar_lookups(
+                        lines, f"{current_field}__{related_name}", related_type
+                    )
+        else:
+            _append_scalar_lookups(lines, current_field, python_type)
 
-            # Determine type for lookup
-            if lookup == "in":
-                lookup_type = f"list[{type_name}] | None"
-            elif lookup == "between":
-                lookup_type = f"tuple[{type_name}, {type_name}] | None"
-            elif lookup == "isnull":
-                lookup_type = "bool | None"
-            elif lookup in DATE_PART_LOOKUPS:
-                lookup_type = "int | None"
-            else:
-                lookup_type = f"{type_name} | None"
-
-            lines.append(f"        {lookup_field}: {lookup_type} = None,")
-
-    return "\n".join(lines)
+    return lines
 
 
 def _generate_order_by_literal(model_class: type[Model]) -> str:
@@ -201,14 +228,38 @@ def _generate_update_params(model_class: type[Model]) -> str:
     return "\n".join(lines)
 
 
+def _get_safe_type_name(python_type: Any, field_name: str) -> str:
+    """Return a type name that won't shadow the field name in a class body."""
+    type_name = _get_python_type_name(python_type)
+    if type_name == field_name:
+        return _SAFE_TYPE_ALIASES.get(type_name, f"_{type_name}")
+    return type_name
+
+
 def _generate_create_params(model_class: type[Model]) -> str:
     """Generate create method parameters with proper optionality."""
     lines = []
     field_info = _get_field_info(model_class)
 
     for field_name, (python_type, _is_pk) in sorted(field_info.items()):
+        if field_name in _CREATE_RESERVED_PARAMS:
+            continue
         type_name = _get_python_type_name(python_type)
         # All create params are optional in stub (instance can be passed instead)
+        lines.append(f"        {field_name}: {type_name} | None = None,")
+
+    return "\n".join(lines)
+
+
+def _generate_init_params(model_class: type[Model]) -> str:
+    """Generate __init__ parameters using safe type aliases to avoid name shadowing."""
+    lines = []
+    field_info = _get_field_info(model_class)
+
+    for field_name, (python_type, _is_pk) in sorted(field_info.items()):
+        if field_name in _CREATE_RESERVED_PARAMS:
+            continue
+        type_name = _get_safe_type_name(python_type, field_name)
         lines.append(f"        {field_name}: {type_name} | None = None,")
 
     return "\n".join(lines)
@@ -248,6 +299,15 @@ def _extract_top_level_copyable(tree: ast.Module) -> list[str]:
     for node in tree.body:
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             result.append(ast.unparse(node))
+        elif (
+            isinstance(node, ast.If)
+            and isinstance(node.test, ast.Name)
+            and node.test.id == "TYPE_CHECKING"
+        ):
+            # Hoist TYPE_CHECKING imports directly — stubs don't need the guard
+            for child in node.body:
+                if isinstance(child, (ast.Import, ast.ImportFrom)):
+                    result.append(ast.unparse(child))
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             # Skip the non-@overload implementation of an overloaded function —
             # `.pyi` cannot contain such an implementation.
@@ -317,6 +377,22 @@ def _generate_model_class_stub(
         else:
             lines.append(f"    {field_name}: {type_name}")
 
+        # Emit companion `{field}_id: int | None` for FK fields
+        if isinstance(python_type, type) and issubclass(python_type, Model):
+            lines.append(f"    {field_name}_id: int | None")
+
+    # Add explicit __init__ so type checkers resolve constructor parameter types against the module
+    # scope rather than the class body scope. This prevents field names that shadow built-in type
+    # names (e.g. a field named "datetime" typed as "datetime | None") from causing false
+    # positives.
+    init_params = _generate_init_params(model_class)
+    lines.append("    def __init__(")
+    lines.append("        self,")
+    lines.append("        *,")
+    if init_params:
+        lines.append(init_params)
+    lines.append("    ) -> None: ...")
+
     # Copy user-defined methods (body replaced by `...`)
     for method_src in custom_methods:
         for raw_line in method_src.splitlines():
@@ -333,7 +409,7 @@ def generate_model_stub(model_class: type[Model]) -> str:
     model_name = model_class.__name__
 
     # Generate model-dependent parameters
-    filter_params = _generate_filter_params(model_class)
+    filter_params = "\n".join(_generate_filter_params(model_class))
     order_by_literal = _generate_order_by_literal(model_class)
     field_literal = _generate_field_literal(model_class)
     create_params = _generate_create_params(model_class)
@@ -360,23 +436,31 @@ class {model_name}Query(Query[{model_name}]):
         \"\"\"Exclude objects matching field lookups.\"\"\"
         ...
 
-    def order_by(self, *fields: {order_by_literal}) -> "{model_name}Query":  # type: ignore[override]
+    @overload
+    def order_by(self, *fields: {order_by_literal}) -> "{model_name}Query": ...
+    @overload
+    def order_by(self, *fields: str) -> "{model_name}Query": ...
+    def order_by(self, *fields: str) -> "{model_name}Query":
         \"\"\"Order results by fields.\"\"\"
         ...
 
-    def limit(self, n: int) -> "{model_name}Query":
+    def limit(self, value: int) -> Self:
         \"\"\"Limit number of results.\"\"\"
         ...
 
-    def offset(self, n: int) -> "{model_name}Query":
+    def offset(self, value: int) -> Self:
         \"\"\"Skip first n results.\"\"\"
         ...
 
-    def distinct(self, value: bool = True) -> "{model_name}Query":
+    def distinct(self, distinct: bool = True) -> Self:
         \"\"\"Return distinct results.\"\"\"
         ...
 
-    def select(self, *fields: {field_literal}) -> "{model_name}Query":  # type: ignore[override]
+    @overload
+    def select(self, *fields: {field_literal}) -> "{model_name}Query": ...
+    @overload
+    def select(self, *fields: str) -> "{model_name}Query": ...
+    def select(self, *fields: str) -> "{model_name}Query":
         \"\"\"Select specific fields.\"\"\"
         ...
 
@@ -400,7 +484,11 @@ class {model_name}Query(Query[{model_name}]):
         \"\"\"Add computed fields using aggregate functions.\"\"\"
         ...
 
-    def group_by(self, *fields: {field_literal}) -> "{model_name}Query":  # type: ignore[override]
+    @overload
+    def group_by(self, *fields: {field_literal}) -> "{model_name}Query": ...
+    @overload
+    def group_by(self, *fields: str) -> "{model_name}Query": ...
+    def group_by(self, *fields: str) -> "{model_name}Query":
         \"\"\"Add GROUP BY clause.\"\"\"
         ...
 
@@ -408,11 +496,19 @@ class {model_name}Query(Query[{model_name}]):
         \"\"\"Add HAVING clause for filtering grouped results.\"\"\"
         ...
 
-    def values(self, *fields: {field_literal}) -> "{model_name}Query":  # type: ignore[override]
+    @overload
+    def values(self, *fields: {field_literal}) -> "{model_name}Query": ...
+    @overload
+    def values(self, *fields: str) -> "{model_name}Query": ...
+    def values(self, *fields: str) -> "{model_name}Query":
         \"\"\"Return dicts instead of models.\"\"\"
         ...
 
-    def values_list(self, *fields: {field_literal}, flat: bool = False) -> "{model_name}Query":  # type: ignore[override]
+    @overload
+    def values_list(self, *fields: {field_literal}, flat: bool = False) -> "{model_name}Query": ...
+    @overload
+    def values_list(self, *fields: str, flat: bool = False) -> "{model_name}Query": ...
+    def values_list(self, *fields: str, flat: bool = False) -> "{model_name}Query":
         \"\"\"Return tuples/values instead of models.\"\"\"
         ...
 
@@ -552,11 +648,19 @@ class {model_name}Manager(QueryManager[{model_name}]):
         \"\"\"Exclude objects matching field lookups.\"\"\"
         ...
 
-    def values(self, *fields: {field_literal}) -> {model_name}Query:  # type: ignore[override]
+    @overload
+    def values(self, *fields: {field_literal}) -> {model_name}Query: ...
+    @overload
+    def values(self, *fields: str) -> {model_name}Query: ...
+    def values(self, *fields: str) -> {model_name}Query:
         \"\"\"Return dicts instead of models.\"\"\"
         ...
 
-    def values_list(self, *fields: {field_literal}, flat: bool = False) -> {model_name}Query:  # type: ignore[override]
+    @overload
+    def values_list(self, *fields: {field_literal}, flat: bool = False) -> {model_name}Query: ...
+    @overload
+    def values_list(self, *fields: str, flat: bool = False) -> {model_name}Query: ...
+    def values_list(self, *fields: str, flat: bool = False) -> {model_name}Query:
         \"\"\"Return tuples/values instead of models.\"\"\"
         ...
 
@@ -624,7 +728,7 @@ class {model_name}Manager(QueryManager[{model_name}]):
         \"\"\"Get object, create if missing, or update it when defaults are provided.\"\"\"
         ...
 
-    async def all(
+    async def all(  # type: ignore[override]
         self,
         *,
         client: Any | None = None,
@@ -738,6 +842,24 @@ class {model_name}Manager(QueryManager[{model_name}]):
     return queryset_class + manager_class
 
 
+def _collect_transitive_models(models: list[type[Model]]) -> set[type[Model]]:
+    """Return all Model classes reachable via FK fields from the given roots."""
+    visited: set[type[Model]] = set()
+
+    def _traverse(model_class: type[Model]) -> None:
+        if model_class in visited:
+            return
+        visited.add(model_class)
+        for _, (python_type, _) in _get_field_info(model_class).items():
+            if isinstance(python_type, type) and issubclass(python_type, Model):
+                _traverse(python_type)
+
+    for model in models:
+        _traverse(model)
+
+    return visited
+
+
 def _build_stub(file_path: Path, models: list[type[Model]]) -> str:
     """Build .pyi stub content for a source file that contains Model classes.
 
@@ -762,8 +884,9 @@ def _build_stub(file_path: Path, models: list[type[Model]]) -> str:
         "# Auto-generated by oxyde generate-stubs",
         "# DO NOT EDIT - This file will be overwritten",
         "",
-        "from typing import Any, ClassVar, Literal",
+        "from typing import Any, ClassVar, Literal, Self, overload",
         "from datetime import datetime, date, time",
+        "from datetime import datetime as _Datetime, date as _Date, time as _Time",
         "from decimal import Decimal",
         "from uuid import UUID",
         "",
@@ -774,6 +897,19 @@ def _build_stub(file_path: Path, models: list[type[Model]]) -> str:
 
     if user_imports:
         parts.extend(user_imports)
+        parts.append("")
+
+    # Add imports for models reachable via nested FKs that aren't defined in this file.
+    # user_imports covers direct FK models (they're imported in the source), but deeper relations
+    # (A → B → C) have no import in the source file.
+    local_models = set(models)
+    external_models = sorted(
+        _collect_transitive_models(models) - local_models,
+        key=lambda m: (m.__module__, m.__name__),
+    )
+    if external_models:
+        for m in external_models:
+            parts.append(f"from {m.__module__} import {m.__name__}")
         parts.append("")
 
     for model in models:

--- a/python/oxyde/migrations/extract.py
+++ b/python/oxyde/migrations/extract.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-from pydantic.fields import PydanticUndefined
+from pydantic_core import PydanticUndefined
 
 from oxyde.models.base import Model
 from oxyde.models.registry import iter_tables, registered_tables

--- a/python/oxyde/models/base.py
+++ b/python/oxyde/models/base.py
@@ -80,8 +80,9 @@ from typing import (
 from pydantic import BaseModel, ConfigDict
 from pydantic._internal._model_construction import ModelMetaclass
 from pydantic.errors import PydanticUndefinedAnnotation
-from pydantic.fields import FieldInfo, PydanticUndefined
-from typing_extensions import dataclass_transform
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+from typing_extensions import Self, dataclass_transform
 
 from oxyde.core import register_validator
 from oxyde.core.ir_types import get_ir_type
@@ -202,7 +203,7 @@ def _get_db_attr(field: FieldInfo, attr_name: str, default: Any = None) -> Any:
 
 @dataclass_transform(
     kw_only_default=True,
-    field_specifiers=(FieldInfo, Field, OxydeFieldInfo),
+    field_specifiers=(OxydeFieldInfo,),
 )
 class Model(BaseModel, metaclass=OxydeModelMeta):
     """Base class for Oxyde ORM models."""
@@ -211,12 +212,12 @@ class Model(BaseModel, metaclass=OxydeModelMeta):
         ignored_types=(RelationDescriptorBase,),
     )
     _db_meta: ClassVar[ModelMeta]
-    objects: ClassVar[QueryManager]
+    objects: ClassVar[QueryManager[Self]]
     _is_table: ClassVar[bool] = False
     __pending_fk_fields__: ClassVar[list[tuple[str, Any, Any]]] = []
     __fk_fields_resolved__: ClassVar[bool] = False
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:
+    def __init_subclass__(cls: type[Self], **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
 
         module = sys.modules.get(cls.__module__)
@@ -691,7 +692,7 @@ class Model(BaseModel, metaclass=OxydeModelMeta):
         client: SupportsExecute | None = None,
         using: str | None = None,
         update_fields: Iterable[str] | None = None,
-    ) -> Model:
+    ) -> Self:
         manager = self.__class__.objects
         pk_field = self.__class__._db_meta.pk_field
         pk_value = getattr(self, pk_field) if pk_field else None
@@ -751,12 +752,12 @@ class Model(BaseModel, metaclass=OxydeModelMeta):
             if not rows:
                 cls_name = self.__class__.__name__
                 raise NotFoundError(f"{cls_name} with {pk_field}={pk_value} not found")
-            self.__dict__.update(rows[0].__dict__)
+            vars(self).update(vars(rows[0]))
         else:
             created = await manager.create(
                 instance=self, client=client, using=using, _skip_hooks=True
             )
-            self.__dict__.update(created.__dict__)
+            vars(self).update(vars(created))
 
         # Call post_save hook
         await self.post_save(is_create=is_create, update_fields=update_fields_set)
@@ -797,7 +798,7 @@ class Model(BaseModel, metaclass=OxydeModelMeta):
         *,
         client: SupportsExecute | None = None,
         using: str | None = None,
-    ) -> Model:
+    ) -> Self:
         """
         Reload this instance from the database.
 

--- a/python/oxyde/models/field.py
+++ b/python/oxyde/models/field.py
@@ -54,7 +54,8 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic.fields import FieldInfo, PydanticUndefined
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
 
 
 class OxydeFieldInfo(FieldInfo):  # type: ignore[misc]

--- a/python/oxyde/models/metadata.py
+++ b/python/oxyde/models/metadata.py
@@ -48,7 +48,7 @@ from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from typing import Any
 
-from pydantic.fields import PydanticUndefined
+from pydantic_core import PydanticUndefined
 
 from oxyde.models.decorators import Check, Index
 

--- a/python/oxyde/queries/base.py
+++ b/python/oxyde/queries/base.py
@@ -186,11 +186,14 @@ def _resolve_pool_name(
             return client._database.name
         else:
             # Unknown client type, try to get name attribute
-            if hasattr(client, "name"):
-                return str(client.name)
-            elif hasattr(client, "_database") and hasattr(client._database, "name"):
-                return str(client._database.name)
-            else:
+            name = getattr(client, "name", None)
+            if name is not None:
+                return str(name)
+            db = getattr(client, "_database", None)
+            if db is not None:
+                db_name = getattr(db, "name", None)
+                if db_name is not None:
+                    return str(db_name)
                 ctype = type(client).__name__
                 raise ManagerError(f"Cannot determine pool name from client: {ctype}")
 

--- a/python/oxyde/queries/manager.py
+++ b/python/oxyde/queries/manager.py
@@ -23,7 +23,7 @@ Example:
 from __future__ import annotations
 
 from collections.abc import Coroutine, Iterable
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, overload
 
 from oxyde.exceptions import IntegrityError, ManagerError, NotFoundError
 from oxyde.models.serializers import _derive_create_data
@@ -46,69 +46,122 @@ class QueryManager(Generic[TModel]):
     def __init__(self, model_class: type[TModel]) -> None:
         self.model_class = model_class
 
-    def _query(self) -> Query:
+    def _query(self) -> Query[TModel]:
         """Create a new Query for this model."""
         return Query(self.model_class)
 
     # --- Query building methods (return Query) ---
 
-    def query(self) -> Query:
+    def query(self) -> Query[TModel]:
         """Return a Query builder for this model."""
         return self._query()
 
-    def filter(self, *args: Any, **kwargs: Any) -> Query:
+    def filter(self, *args: Any, **kwargs: Any) -> Query[TModel]:
         """Filter by Q-expressions or field lookups."""
         return self._query().filter(*args, **kwargs)
 
-    def exclude(self, *args: Any, **kwargs: Any) -> Query:
+    def exclude(self, *args: Any, **kwargs: Any) -> Query[TModel]:
         """Exclude rows matching conditions (NOT filter)."""
         return self._query().exclude(*args, **kwargs)
 
-    def values(self, *fields: str) -> Query:
+    def values(self, *fields: str) -> Query[TModel]:
         """Return dicts instead of models."""
         return self._query().values(*fields)
 
-    def values_list(self, *fields: str, flat: bool = False) -> Query:
+    def values_list(self, *fields: str, flat: bool = False) -> Query[TModel]:
         """Return tuples/lists instead of models."""
         return self._query().values_list(*fields, flat=flat)
 
-    def distinct(self, distinct: bool = True) -> Query:
+    def distinct(self, distinct: bool = True) -> Query[TModel]:
         """Add DISTINCT to query."""
         return self._query().distinct(distinct)
 
-    def join(self, *paths: str) -> Query:
+    def join(self, *paths: str) -> Query[TModel]:
         """Eager load relations via JOIN."""
         return self._query().join(*paths)
 
-    def prefetch(self, *paths: str) -> Query:
+    def prefetch(self, *paths: str) -> Query[TModel]:
         """Prefetch relations in separate queries."""
         return self._query().prefetch(*paths)
 
-    def for_update(self) -> Query:
+    def for_update(self) -> Query[TModel]:
         """Add FOR UPDATE lock."""
         return self._query().for_update()
 
-    def for_share(self) -> Query:
+    def for_share(self) -> Query[TModel]:
         """Add FOR SHARE lock."""
         return self._query().for_share()
 
-    def order_by(self, *fields: str) -> Query:
+    def order_by(self, *fields: str) -> Query[TModel]:
         """Order results by fields. Prefix with '-' for descending."""
         return self._query().order_by(*fields)
 
-    def limit(self, value: int) -> Query:
+    def limit(self, value: int) -> Query[TModel]:
         """Limit number of results."""
         return self._query().limit(value)
 
-    def offset(self, value: int) -> Query:
+    def offset(self, value: int) -> Query[TModel]:
         """Skip first N results."""
         return self._query().offset(value)
 
-    def annotate(self, **annotations: Any) -> Query:
+    def annotate(self, **annotations: Any) -> Query[TModel]:
         """Add aggregate annotations."""
         return self._query().annotate(**annotations)
 
     # --- Execution methods (delegate to Query) ---
+
+    @overload
+    def all(
+        self,
+        *,
+        using: str | None = ...,
+        client: SupportsExecute | None = ...,
+        mode: Literal["models"],
+    ) -> Coroutine[Any, Any, list[TModel]]: ...
+
+    @overload
+    def all(
+        self,
+        *,
+        using: str | None = ...,
+        client: SupportsExecute | None = ...,
+    ) -> Coroutine[Any, Any, list[TModel]]: ...
+
+    @overload
+    def all(
+        self,
+        *,
+        using: str | None = ...,
+        client: SupportsExecute | None = ...,
+        mode: Literal["msgpack"],
+    ) -> Coroutine[Any, Any, bytes]: ...
+
+    @overload
+    def all(
+        self,
+        *,
+        using: str | None = ...,
+        client: SupportsExecute | None = ...,
+        mode: Literal["dict"],
+    ) -> Coroutine[Any, Any, list[dict[str, Any]]]: ...
+
+    @overload
+    def all(
+        self,
+        *,
+        using: str | None = ...,
+        client: SupportsExecute | None = ...,
+        mode: Literal["list"],
+    ) -> Coroutine[Any, Any, list[tuple[Any, ...]]]: ...
+
+    @overload
+    def all(
+        self,
+        *,
+        using: str | None = ...,
+        client: SupportsExecute | None = ...,
+        mode: str,
+    ) -> Coroutine[Any, Any, bytes | list[Any]]: ...
 
     def all(
         self,
@@ -138,7 +191,7 @@ class QueryManager(Generic[TModel]):
         *,
         using: str | None = None,
         client: SupportsExecute | None = None,
-    ) -> Model | None:
+    ) -> TModel | None:
         """Return first result or None."""
         return await self._query().first(using=using, client=client)
 
@@ -147,7 +200,7 @@ class QueryManager(Generic[TModel]):
         *,
         using: str | None = None,
         client: SupportsExecute | None = None,
-    ) -> Model | None:
+    ) -> TModel | None:
         """Return last result or None."""
         return await self._query().last(using=using, client=client)
 
@@ -157,7 +210,7 @@ class QueryManager(Generic[TModel]):
         using: str | None = None,
         client: SupportsExecute | None = None,
         **filters: Any,
-    ) -> Model:
+    ) -> TModel:
         """Return exactly one result. Raises NotFoundError/MultipleObjectsReturned."""
         q = self._query()
         if filters:
@@ -170,7 +223,7 @@ class QueryManager(Generic[TModel]):
         using: str | None = None,
         client: SupportsExecute | None = None,
         **filters: Any,
-    ) -> Model | None:
+    ) -> TModel | None:
         """Return one result or None. Raises MultipleObjectsReturned if many."""
         q = self._query()
         if filters:
@@ -184,7 +237,7 @@ class QueryManager(Generic[TModel]):
         using: str | None = None,
         client: SupportsExecute | None = None,
         **filters: Any,
-    ) -> tuple[Model, bool]:
+    ) -> tuple[TModel, bool]:
         """Get existing object or create a new one.
 
         Args:
@@ -276,7 +329,7 @@ class QueryManager(Generic[TModel]):
         client: SupportsExecute | None = None,
         _skip_hooks: bool = False,
         **data: Any,
-    ) -> Model:
+    ) -> TModel:
         """Create a new record in the database."""
         return await self._query().create(
             instance=instance,
@@ -293,7 +346,7 @@ class QueryManager(Generic[TModel]):
         using: str | None = None,
         client: SupportsExecute | None = None,
         batch_size: int | None = None,
-    ) -> list[Model]:
+    ) -> list[TModel]:
         """Bulk insert multiple objects efficiently."""
         return await self._query().bulk_create(
             objects,
@@ -304,7 +357,7 @@ class QueryManager(Generic[TModel]):
 
     async def bulk_update(
         self,
-        objects: Iterable[Model],
+        objects: Iterable[TModel],
         fields: Iterable[str],
         *,
         using: str | None = None,
@@ -325,7 +378,7 @@ class QueryManager(Generic[TModel]):
         using: str | None = None,
         client: SupportsExecute | None = None,
         **filters: Any,
-    ) -> tuple[Model, bool]:
+    ) -> tuple[TModel, bool]:
         """Get existing object and update it, or create it if it does not exist.
 
         Args:

--- a/python/oxyde/queries/mixins/execution.py
+++ b/python/oxyde/queries/mixins/execution.py
@@ -554,7 +554,7 @@ class ExecutionMixin:
             if descriptor is not None and hasattr(descriptor, "__set__"):
                 descriptor.__set__(parent, list(values))
             else:
-                parent.__dict__[relation_name] = list(values)
+                setattr(parent, relation_name, list(values))
 
         if len(segments) > 1:
             nested_children: list[Model] = [
@@ -677,4 +677,4 @@ class ExecutionMixin:
             if descriptor is not None and hasattr(descriptor, "__set__"):
                 descriptor.__set__(parent, list(values))
             else:
-                parent.__dict__[relation_name] = list(values)
+                setattr(parent, relation_name, list(values))

--- a/python/oxyde/queries/mixins/mutation.py
+++ b/python/oxyde/queries/mixins/mutation.py
@@ -122,7 +122,7 @@ class MutationMixin:
         using: str | None = ...,
         client: SupportsExecute | None = ...,
         **values: Any,
-    ) -> list[Model]: ...
+    ) -> list[Any]: ...
 
     @overload
     async def update(

--- a/python/oxyde/queries/select.py
+++ b/python/oxyde/queries/select.py
@@ -53,6 +53,7 @@ Example:
 
 from __future__ import annotations
 
+from collections.abc import Coroutine
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from typing_extensions import Self
@@ -308,6 +309,72 @@ class Query(
             count=self._count or None,
             exists=self._exists or None,
         )
+
+    # Narrow inherited mixin return types from Model → TModel for type checkers.
+    # These stubs are only visible to type checkers; the mixin implementations
+    # run at runtime (they are already correct since model_class carries the type).
+    if TYPE_CHECKING:
+        from collections.abc import Iterable
+
+        from oxyde.queries.base import SupportsExecute
+
+        async def fetch_models(  # type: ignore
+            self, client: SupportsExecute
+        ) -> list[TModel]: ...
+
+        def all(  # type: ignore
+            self,
+            *,
+            using: str | None = None,
+            client: SupportsExecute | None = None,
+        ) -> Coroutine[Any, Any, list[TModel]]: ...
+
+        async def get(
+            self,
+            *,
+            using: str | None = None,
+            client: SupportsExecute | None = None,
+        ) -> TModel: ...
+
+        async def get_or_none(
+            self,
+            *,
+            using: str | None = None,
+            client: SupportsExecute | None = None,
+        ) -> TModel | None: ...
+
+        async def first(
+            self,
+            *,
+            using: str | None = None,
+            client: SupportsExecute | None = None,
+        ) -> TModel | None: ...
+
+        async def last(
+            self,
+            *,
+            using: str | None = None,
+            client: SupportsExecute | None = None,
+        ) -> TModel | None: ...
+
+        async def create(
+            self,
+            *,
+            instance: Model | None = None,
+            using: str | None = None,
+            client: SupportsExecute | None = None,
+            _skip_hooks: bool = False,
+            **data: Any,
+        ) -> TModel: ...
+
+        async def bulk_create(  # type: ignore
+            self,
+            objects: Iterable[Any],
+            *,
+            using: str | None = None,
+            client: SupportsExecute | None = None,
+            batch_size: int | None = None,
+        ) -> list[TModel]: ...
 
 
 __all__ = ["Query"]

--- a/python/oxyde/tests/typecheck/fixtures/edges/fk_filter_traversal/module.py
+++ b/python/oxyde/tests/typecheck/fixtures/edges/fk_filter_traversal/module.py
@@ -1,0 +1,22 @@
+"""Edge: stub filter params include double-underscore FK traversal lookups."""
+
+from __future__ import annotations
+
+from oxyde import Field, Model
+
+
+class Author(Model):
+    id: int | None = Field(default=None, db_pk=True)
+    name: str = Field(default="")
+
+    class Meta:
+        is_table = True
+
+
+class Post(Model):
+    id: int | None = Field(default=None, db_pk=True)
+    title: str = Field(default="")
+    author: Author | None = Field(default=None)
+
+    class Meta:
+        is_table = True

--- a/python/oxyde/tests/typecheck/fixtures/edges/fk_filter_traversal/usage.py
+++ b/python/oxyde/tests/typecheck/fixtures/edges/fk_filter_traversal/usage.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from module import Post
+
+
+async def filter_by_fk_scalar() -> list[Post]:
+    return await Post.objects.filter(author__name__icontains="alice").all()
+
+
+async def filter_by_fk_isnull() -> list[Post]:
+    return await Post.objects.filter(author__isnull=True).all()
+
+
+async def filter_by_title_and_fk() -> list[Post]:
+    return await Post.objects.filter(
+        title__startswith="Hello",
+        author__name="Bob",
+    ).all()

--- a/python/oxyde/tests/typecheck/fixtures/edges/fk_id_companion/module.py
+++ b/python/oxyde/tests/typecheck/fixtures/edges/fk_id_companion/module.py
@@ -1,0 +1,22 @@
+"""Edge: stub filter params include the FK companion {field}_id int field."""
+
+from __future__ import annotations
+
+from oxyde import Field, Model
+
+
+class Tag(Model):
+    id: int | None = Field(default=None, db_pk=True)
+    name: str = Field(default="")
+
+    class Meta:
+        is_table = True
+
+
+class Article(Model):
+    id: int | None = Field(default=None, db_pk=True)
+    title: str = Field(default="")
+    tag: Tag | None = Field(default=None)
+
+    class Meta:
+        is_table = True

--- a/python/oxyde/tests/typecheck/fixtures/edges/fk_id_companion/usage.py
+++ b/python/oxyde/tests/typecheck/fixtures/edges/fk_id_companion/usage.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from module import Article
+
+
+async def filter_by_companion_id() -> list[Article]:
+    return await Article.objects.filter(tag_id=1).all()
+
+
+async def filter_by_companion_id_in() -> list[Article]:
+    return await Article.objects.filter(tag_id__in=[1, 2, 3]).all()
+
+
+async def filter_companion_isnull() -> list[Article]:
+    return await Article.objects.filter(tag_id__isnull=True).all()

--- a/python/oxyde/tests/typecheck/test_typecheck_e2e.py
+++ b/python/oxyde/tests/typecheck/test_typecheck_e2e.py
@@ -26,6 +26,8 @@ FIXTURES: list[tuple[str, str, str, str]] = [
     ("edges/inheritance_chain", "edges/inheritance_chain", "module", "usage.py"),
     ("edges/reserved_names", "edges/reserved_names", "module", "usage.py"),
     ("edges/generics_in_field", "edges/generics_in_field", "module", "usage.py"),
+    ("edges/fk_filter_traversal", "edges/fk_filter_traversal", "module", "usage.py"),
+    ("edges/fk_id_companion", "edges/fk_id_companion", "module", "usage.py"),
 ]
 
 
@@ -72,33 +74,11 @@ def test_mypy_accepts_generated_stubs(
     )
 
 
-# Per-fixture marks for the model-source check. ``mixed_module`` calls
-# ``Note.objects.all()`` from inside the model file itself, which exercises
-# QueryManager/Query typing rather than the Field-assignment fix this suite
-# is about. Stubs cover the cross-module case; in-file manager calls remain
-# untyped until QueryManager/Query gain proper Generic[TModel] propagation.
-_MODEL_SOURCE_XFAIL = {
-    "edges/mixed_module": pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "QueryManager.all() declared as Coroutine[..., bytes | list[Any]] "
-            "and Model.objects is ClassVar[QueryManager] without TModel. "
-            "Stubs cover cross-module imports; in-file Model.objects.xxx() "
-            "calls require Generic[TModel] propagation through the manager, "
-            "Query and ExecutionMixin. Tracked as a follow-up to issue #13."
-        ),
-    ),
-}
-
-
 def _model_source_params() -> list:
-    params = []
-    for test_id, fixture_dir, model_module, usage_file in FIXTURES:
-        marks = (_MODEL_SOURCE_XFAIL[test_id],) if test_id in _MODEL_SOURCE_XFAIL else ()
-        params.append(
-            pytest.param(fixture_dir, model_module, usage_file, id=test_id, marks=marks)
-        )
-    return params
+    return [
+        pytest.param(fixture_dir, model_module, usage_file, id=test_id)
+        for test_id, fixture_dir, model_module, usage_file in FIXTURES
+    ]
 
 
 @pytest.mark.parametrize(

--- a/python/oxyde/tests/unit/test_stub_generator.py
+++ b/python/oxyde/tests/unit/test_stub_generator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 from datetime import date, datetime, time
 from decimal import Decimal
 from uuid import UUID
@@ -9,7 +10,57 @@ from uuid import UUID
 import pytest
 
 from oxyde import Field, Model
-from oxyde.codegen.stub_generator import _get_python_type_name
+from oxyde.codegen.stub_generator import (
+    _collect_transitive_models,
+    _extract_top_level_copyable,
+    _generate_create_params,
+    _generate_filter_params,
+    _generate_init_params,
+    _get_python_type_name,
+    _get_safe_type_name,
+    _has_overload_decorator,
+)
+
+
+class _Leaf(Model):
+    id: int | None = Field(default=None, db_pk=True)
+    value: str = Field(default="")
+
+    class Meta:
+        is_table = True
+        table_name = "_stub_test_leaf"
+
+
+class _Node(Model):
+    id: int | None = Field(default=None, db_pk=True)
+    label: str = Field(default="")
+    leaf: _Leaf | None = Field(default=None)
+
+    class Meta:
+        is_table = True
+        table_name = "_stub_test_node"
+
+
+class _Root(Model):
+    id: int | None = Field(default=None, db_pk=True)
+    name: str = Field(default="")
+    node: _Node | None = Field(default=None)
+
+    class Meta:
+        is_table = True
+        table_name = "_stub_test_root"
+
+
+class _WithReserved(Model):
+    """Model that includes fields whose names are reserved create()/all() params."""
+
+    id: int | None = Field(default=None, db_pk=True)
+    name: str = Field(default="")
+    using: str = Field(default="")
+
+    class Meta:
+        is_table = True
+        table_name = "_stub_test_reserved"
 
 
 class TestGetPythonTypeName:
@@ -72,3 +123,300 @@ class TestGetPythonTypeName:
                 is_table = True
 
         assert _get_python_type_name(MyModel) == "MyModel"
+
+
+class TestGetSafeTypeName:
+    """_get_safe_type_name returns an alias when field_name would shadow its type."""
+
+    def test_no_conflict_returns_plain_type(self):
+        assert _get_safe_type_name(str, "title") == "str"
+        assert _get_safe_type_name(int, "count") == "int"
+        assert _get_safe_type_name(bool, "active") == "bool"
+
+    def test_datetime_field_name_returns_alias(self):
+        assert _get_safe_type_name(datetime, "datetime") == "_Datetime"
+
+    def test_date_field_name_returns_alias(self):
+        assert _get_safe_type_name(date, "date") == "_Date"
+
+    def test_time_field_name_returns_alias(self):
+        assert _get_safe_type_name(time, "time") == "_Time"
+
+    def test_non_alias_type_name_conflict_gets_underscore_prefix(self):
+        # A type not in _SAFE_TYPE_ALIASES whose name matches the field name falls
+        # back to the "_<type_name>" pattern.
+        assert _get_safe_type_name(str, "str") == "_str"
+
+    def test_datetime_field_with_different_name_is_not_aliased(self):
+        assert _get_safe_type_name(datetime, "created_at") == "datetime"
+        assert _get_safe_type_name(datetime, "started_at") == "datetime"
+
+    def test_date_field_with_different_name_is_not_aliased(self):
+        assert _get_safe_type_name(date, "published_on") == "date"
+
+    def test_time_field_with_different_name_is_not_aliased(self):
+        assert _get_safe_type_name(time, "publish_time") == "time"
+
+
+class TestGenerateInitParams:
+    def test_basic_fields_included(self):
+        result = _generate_init_params(_Leaf)
+        assert "id: int | None = None," in result
+        assert "value: str | None = None," in result
+
+    def test_reserved_params_excluded(self):
+        # "using" is in _CREATE_RESERVED_PARAMS so it must be absent
+        result = _generate_init_params(_WithReserved)
+        assert "name: str | None = None," in result
+        assert "id: int | None = None," in result
+        assert "using" not in result
+
+    def test_datetime_field_with_distinct_name_uses_plain_type(self):
+        # A field named "created_at" typed as datetime has no name/type conflict,
+        # so the plain "datetime" name is used (not the alias).
+        class _Timestamped(Model):
+            id: int | None = Field(default=None, db_pk=True)
+            created_at: datetime | None = Field(default=None)
+
+            class Meta:
+                is_table = True
+                table_name = "_stub_test_ts"
+
+        result = _generate_init_params(_Timestamped)
+        assert "created_at: datetime | None = None," in result
+
+    def test_fk_field_uses_model_name_as_type(self):
+        result = _generate_init_params(_Node)
+        # FK field "leaf" typed as _Leaf → type name is "_Leaf"
+        assert "leaf: _Leaf | None = None," in result
+
+
+class TestGenerateCreateParams:
+    def test_basic_fields_included(self):
+        result = _generate_create_params(_Leaf)
+        assert "id: int | None = None," in result
+        assert "value: str | None = None," in result
+
+    def test_reserved_params_excluded(self):
+        # "using" is a create() reserved kwarg and must be absent
+        result = _generate_create_params(_WithReserved)
+        assert "name: str | None = None," in result
+        assert "using" not in result
+
+    def test_all_three_reserved_names_excluded(self):
+        # Verify each reserved name independently using a model with each
+        for reserved in ("instance", "client", "using"):
+
+            class _R(Model):
+                id: int | None = Field(default=None, db_pk=True)
+
+                class Meta:
+                    is_table = True
+                    table_name = f"_stub_test_reserved_{reserved}"
+
+            # Manually inject the reserved field into model_fields for testing
+            # by checking _CREATE_RESERVED_PARAMS content instead
+            from oxyde.codegen.stub_generator import _CREATE_RESERVED_PARAMS
+
+            assert reserved in _CREATE_RESERVED_PARAMS
+
+
+class TestHasOverloadDecorator:
+    def _parse_func(self, src: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+        tree = ast.parse(src)
+        node = tree.body[0]
+        assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        return node
+
+    def test_plain_function_returns_false(self):
+        node = self._parse_func("def foo(): ...")
+        assert not _has_overload_decorator(node)
+
+    def test_overload_by_name_returns_true(self):
+        node = self._parse_func("@overload\ndef foo(): ...")
+        assert _has_overload_decorator(node)
+
+    def test_overload_attribute_form_returns_true(self):
+        node = self._parse_func("@typing.overload\ndef foo(): ...")
+        assert _has_overload_decorator(node)
+
+    def test_other_decorator_returns_false(self):
+        node = self._parse_func("@staticmethod\ndef foo(): ...")
+        assert not _has_overload_decorator(node)
+
+    def test_async_function_supported(self):
+        node = self._parse_func("@overload\nasync def foo(): ...")
+        assert _has_overload_decorator(node)
+
+    def test_multiple_decorators_one_overload(self):
+        src = "@some_decorator\n@overload\ndef foo(): ..."
+        node = self._parse_func(src)
+        assert _has_overload_decorator(node)
+
+
+class TestExtractTopLevelCopyable:
+    """Test TYPE_CHECKING import hoisting"""
+    def _parse(self, src: str) -> ast.Module:
+        return ast.parse(src)
+
+    def test_regular_imports_included(self):
+        tree = self._parse("import os\nfrom pathlib import Path")
+        result = _extract_top_level_copyable(tree)
+        assert "import os" in result
+        assert "from pathlib import Path" in result
+
+    def test_type_checking_block_imports_hoisted(self):
+        src = (
+            "from typing import TYPE_CHECKING\n"
+            "if TYPE_CHECKING:\n"
+            "    from some_module import SomeType\n"
+            "    from other import OtherType\n"
+        )
+        tree = self._parse(src)
+        result = _extract_top_level_copyable(tree)
+        combined = "\n".join(result)
+        assert "from some_module import SomeType" in combined
+        assert "from other import OtherType" in combined
+
+    def test_non_type_checking_if_block_not_hoisted(self):
+        src = "if True:\n    from secret import Something\n"
+        tree = self._parse(src)
+        result = _extract_top_level_copyable(tree)
+        assert not any("secret" in line for line in result)
+
+    def test_overload_implementation_dropped(self):
+        src = (
+            "from typing import overload\n"
+            "@overload\n"
+            "def foo(x: int) -> str: ...\n"
+            "@overload\n"
+            "def foo(x: str) -> int: ...\n"
+            "def foo(x):\n"
+            "    return x\n"
+        )
+        tree = self._parse(src)
+        result = _extract_top_level_copyable(tree)
+        # Both @overload stubs kept; bare implementation dropped
+        func_lines = [r for r in result if "def foo" in r]
+        assert len(func_lines) == 2
+        assert all("overload" in s for s in func_lines)
+
+    def test_plain_function_included(self):
+        src = "def helper(x: int) -> str: ...\n"
+        tree = self._parse(src)
+        result = _extract_top_level_copyable(tree)
+        assert any("def helper" in r for r in result)
+
+    def test_type_checking_non_import_children_ignored(self):
+        src = "if TYPE_CHECKING:\n    x = 1\n"
+        tree = self._parse(src)
+        result = _extract_top_level_copyable(tree)
+        # Assignment inside TYPE_CHECKING is not an import → not hoisted
+        assert not any("x = 1" in line for line in result)
+
+
+class TestGenerateFilterParams:
+    """Test FK traversal"""
+    def _param_names(self, lines: list[str]) -> set[str]:
+        """Extract parameter names (before ':') from filter param lines."""
+        names = set()
+        for line in lines:
+            stripped = line.strip()
+            if ":" in stripped:
+                names.add(stripped.split(":")[0].strip())
+        return names
+
+    def test_scalar_fields_generate_exact_and_lookups(self):
+        lines = _generate_filter_params(_Leaf)
+        names = self._param_names(lines)
+        # Exact match params
+        assert "id" in names
+        assert "value" in names
+        # Lookup suffix for str
+        assert "value__icontains" in names
+        assert "value__startswith" in names
+        # Lookup suffix for int
+        assert "id__gte" in names
+        assert "id__in" in names
+
+    def test_fk_field_emits_isnull_and_related_scalar_params(self):
+        lines = _generate_filter_params(_Node)
+        names = self._param_names(lines)
+        # FK itself with isnull
+        assert "leaf" in names
+        assert "leaf__isnull" in names
+        # Related model's scalar fields traversed with double-underscore prefix
+        assert "leaf__value" in names
+        assert "leaf__value__icontains" in names
+        assert "leaf__id" in names
+        assert "leaf__id__gte" in names
+
+    def test_nested_fk_traversal_two_hops(self):
+        # _Root.node (FK → _Node) and _Node.leaf (FK → _Leaf)
+        lines = _generate_filter_params(_Root)
+        names = self._param_names(lines)
+        # Direct FK at first hop
+        assert "node" in names
+        assert "node__isnull" in names
+        # One hop: _Node scalar fields
+        assert "node__label" in names
+        # Two hops: _Leaf scalar fields reachable via node__leaf__ prefix
+        assert "node__leaf__value" in names
+        assert "node__leaf__id" in names
+        assert "node__leaf__value__icontains" in names
+
+    def test_returns_list_of_strings(self):
+        result = _generate_filter_params(_Leaf)
+        assert isinstance(result, list)
+        assert all(isinstance(line, str) for line in result)
+
+    def test_prefix_argument_prepends_to_all_param_names(self):
+        lines = _generate_filter_params(_Leaf, prefix="parent")
+        names = self._param_names(lines)
+        assert all(name.startswith("parent__") for name in names)
+        assert "parent__id" in names
+        assert "parent__value" in names
+
+    def test_no_fk_field_in_filter_params_for_leaf_model(self):
+        lines = _generate_filter_params(_Leaf)
+        names = self._param_names(lines)
+        # _Leaf has no FK fields; every param prefix must be a _Leaf scalar field
+        for name in names:
+            prefix = name.split("__")[0]
+            assert prefix in ("id", "value"), f"unexpected FK-derived param: {name}"
+
+
+class TestCollectTransitiveModels:
+    def test_model_with_no_fks_returns_only_itself(self):
+        result = _collect_transitive_models([_Leaf])
+        assert result == {_Leaf}
+
+    def test_direct_fk_includes_both_models(self):
+        result = _collect_transitive_models([_Node])
+        assert _Node in result
+        assert _Leaf in result
+
+    def test_transitive_fk_includes_all_reachable_models(self):
+        # _Root → _Node → _Leaf
+        result = _collect_transitive_models([_Root])
+        assert _Root in result
+        assert _Node in result
+        assert _Leaf in result
+
+    def test_multiple_roots_unioned(self):
+        result = _collect_transitive_models([_Leaf, _Node])
+        assert _Leaf in result
+        assert _Node in result
+
+    def test_returns_set(self):
+        result = _collect_transitive_models([_Root])
+        assert isinstance(result, set)
+
+    def test_duplicate_roots_not_traversed_twice(self):
+        # Passing _Leaf twice shouldn't cause errors or duplicates in a set
+        result = _collect_transitive_models([_Leaf, _Leaf])
+        assert result == {_Leaf}
+
+    def test_empty_list_returns_empty_set(self):
+        result = _collect_transitive_models([])
+        assert result == set()


### PR DESCRIPTION
## Summary

At present, Oxyde's type hints indicate that `Field` returns an instance of `OxydeFieldInfo` (#13), and that queries return instances of `Model` rather than the defined class (#10). In addition, stub generation omitted fields from FKs. These three issues result in type checkers like Pyright and Ty flagging unknown attribute errors and type assignment errors in a codebase that uses Oxyde.

## Changes

This PR does not change any core functionality, rather it updates the type hinting and stub generation to address the above issues. Specifically:
- Fixes #10 by changing the return type hints to the model type being queried
- Fixes #13 by using `pydantic_core.PydanticUndefined` in place of `pydantic.fields.PydanticUndefined` (a Pydantic v2 API change)
- Adds filter params for FKs, including nested FKs, which matches [documented functionality](https://oxyde.fatalyst.dev/0.6/guide/filtering/#related-field-lookups-fk-traversal) (note that these changes weren't extended to `order_by()` because it doesn't currently support ordering based on FK fields).

## Testing

- All existing tests
- Migrated medium-sized CRUD API from Tortoise ORM to Oxyde to verify changes
  - with v0.7.0, Ty outputs 608 diagnostics
  - with this PR, Ty outputs 0 diagnostics

## Notes

It'd probably be worth investigating why the existing type checks tests aren't catching these issues, since we know Mypy can flag them.

Thanks for an awesome library! Looking forward to migrating more projects over to it.