### PR TITLE
Detect changed Check constraint expressions in migrations

### DIFF
--- a/crates/oxyde-migrate/src/diff.rs
+++ b/crates/oxyde-migrate/src/diff.rs
@@ -316,23 +316,37 @@ pub fn compute_diff(old: &Snapshot, new: &Snapshot) -> Result<Vec<MigrationOp>> 
                 }
             }
 
+            // Find dropped and changed check constraints
+            for old_check in &old_table.checks {
+                match new_table.checks.iter().find(|c| c.name == old_check.name) {
+                    Some(new_check) if new_check.expression != old_check.expression => {
+                        ops.push(MigrationOp::DropCheck {
+                            table: name.clone(),
+                            name: old_check.name.clone(),
+                            check_def: Some(old_check.clone()),
+                        });
+                        ops.push(MigrationOp::AddCheck {
+                            table: name.clone(),
+                            check: new_check.clone(),
+                        });
+                    }
+                    None => {
+                        ops.push(MigrationOp::DropCheck {
+                            table: name.clone(),
+                            name: old_check.name.clone(),
+                            check_def: Some(old_check.clone()),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+
             // Find added check constraints
             for new_check in &new_table.checks {
                 if !old_table.checks.iter().any(|c| c.name == new_check.name) {
                     ops.push(MigrationOp::AddCheck {
                         table: name.clone(),
                         check: new_check.clone(),
-                    });
-                }
-            }
-
-            // Find dropped check constraints
-            for old_check in &old_table.checks {
-                if !new_table.checks.iter().any(|c| c.name == old_check.name) {
-                    ops.push(MigrationOp::DropCheck {
-                        table: name.clone(),
-                        name: old_check.name.clone(),
-                        check_def: Some(old_check.clone()),
                     });
                 }
             }

--- a/crates/oxyde-migrate/tests/migration_tests.rs
+++ b/crates/oxyde-migrate/tests/migration_tests.rs
@@ -66,6 +66,50 @@ fn test_snapshot_serialization_roundtrip() {
 }
 
 #[test]
+fn test_check_constraint_expression_change_generates_drop_and_add() {
+    let mut old = Snapshot::new();
+    let mut old_table = sample_table();
+    old_table.checks.push(CheckDef {
+        name: "age_positive".into(),
+        expression: "age >= 0".into(),
+    });
+    old.add_table(old_table);
+
+    let mut new = Snapshot::new();
+    let mut new_table = sample_table();
+    new_table.checks.push(CheckDef {
+        name: "age_positive".into(),
+        expression: "age > 0".into(),
+    });
+    new.add_table(new_table);
+
+    let ops = compute_diff(&old, &new).unwrap();
+    assert_eq!(ops.len(), 2);
+
+    match &ops[0] {
+        MigrationOp::DropCheck {
+            table,
+            name,
+            check_def,
+        } => {
+            assert_eq!(table, "users");
+            assert_eq!(name, "age_positive");
+            assert_eq!(check_def.as_ref().unwrap().expression, "age >= 0");
+        }
+        op => panic!("expected DropCheck, got {:?}", op),
+    }
+
+    match &ops[1] {
+        MigrationOp::AddCheck { table, check } => {
+            assert_eq!(table, "users");
+            assert_eq!(check.name, "age_positive");
+            assert_eq!(check.expression, "age > 0");
+        }
+        op => panic!("expected AddCheck, got {:?}", op),
+    }
+}
+
+#[test]
 fn test_migration_create_table_generates_sql() {
     let sql = MigrationOp::CreateTable {
         table: sample_table(),

--- a/python/oxyde/tests/unit/test_migrations_execution.py
+++ b/python/oxyde/tests/unit/test_migrations_execution.py
@@ -910,6 +910,27 @@ class TestMigrationInvariants:
         migration_to_sql(ops_json, dialect)
 
     @pytest.mark.parametrize("dialect", NON_SQLITE)
+    def test_roundtrip_change_check_expression(self, dialect):
+        old = _base_snapshot()
+        old["tables"]["users"]["checks"].append(
+            {"name": "chk_users_age", "expression": "age >= 0"}
+        )
+        new = _base_snapshot()
+        new["tables"]["users"]["checks"].append(
+            {"name": "chk_users_age", "expression": "age > 0"}
+        )
+
+        ops_json = migration_compute_diff(json.dumps(old), json.dumps(new))
+        ops = json.loads(ops_json)
+
+        assert [op["type"] for op in ops] == ["drop_check", "add_check"]
+        assert ops[0]["name"] == "chk_users_age"
+        assert ops[0]["check_def"]["expression"] == "age >= 0"
+        assert ops[1]["check"]["name"] == "chk_users_age"
+        assert ops[1]["check"]["expression"] == "age > 0"
+        migration_to_sql(ops_json, dialect)
+
+    @pytest.mark.parametrize("dialect", NON_SQLITE)
     def test_roundtrip_drop_check(self, dialect):
         old = _base_snapshot()
         old["tables"]["users"]["checks"].append(


### PR DESCRIPTION
  Closes #39

  Fixes makemigrations not detecting changes to an existing Check constraint when the constraint name stays the same.

  Before this change, the migration diff only compared check constraints by name, so this produced no migration:

  `Check("age >= 0", name="chk_users_age")`

  when changed to:

  `Check("age > 0", name="chk_users_age")`

  Now the diff detects same-name expression changes and emits:

  1. drop_check for the old constraint
  2. add_check for the new constraint

  The drop happens first because the replacement uses the same constraint name.
  
  Reordered logic in crates/oxyde-migrate/src/diff.rs so changed same-name checks can be handled as drop_check then add_check.

  Testing

  cargo test -p oxyde-migrate --quiet
  cargo test --workspace --exclude oxyde-core-py --quiet
  uv run --project python --extra dev --no-sync pytest -q python/oxyde/tests/unit/test_migrations_execution.py