### PR TITLE
Add first-class enum support

### DIFF
--- a/crates/oxyde-codec/src/lib.rs
+++ b/crates/oxyde-codec/src/lib.rs
@@ -130,6 +130,10 @@ pub enum ColumnTypeSpec {
     Json,
     /// JSONB on Postgres; identical to Json elsewhere.
     JsonBinary,
+    Enum {
+        name: String,
+        values: Vec<String>,
+    },
     Array {
         item: Box<ColumnTypeSpec>,
     },
@@ -614,6 +618,19 @@ mod tests {
     }
 
     #[test]
+    fn test_spec_enum() {
+        assert_eq!(
+            spec_from_json(
+                r#"{"kind": "enum", "name": "post_status_enum", "values": ["draft", "published"]}"#
+            ),
+            ColumnTypeSpec::Enum {
+                name: "post_status_enum".into(),
+                values: vec!["draft".into(), "published".into()],
+            }
+        );
+    }
+
+    #[test]
     fn test_spec_unknown_kind_is_error() {
         let result: std::result::Result<ColumnTypeSpec, _> =
             serde_json::from_str(r#"{"kind": "flux_capacitor"}"#);
@@ -631,6 +648,10 @@ mod tests {
             },
             ColumnTypeSpec::Array {
                 item: Box::new(ColumnTypeSpec::Uuid),
+            },
+            ColumnTypeSpec::Enum {
+                name: "post_status_enum".into(),
+                values: vec!["draft".into(), "published".into()],
             },
             ColumnTypeSpec::Unknown,
         ];

--- a/crates/oxyde-driver/src/convert/mysql.rs
+++ b/crates/oxyde-driver/src/convert/mysql.rs
@@ -31,7 +31,7 @@ impl CellEncoder for MySqlEncoder {
                 }
                 true
             }
-            ColumnTypeSpec::Text | ColumnTypeSpec::String { .. } => {
+            ColumnTypeSpec::Text | ColumnTypeSpec::String { .. } | ColumnTypeSpec::Enum { .. } => {
                 match row.try_get::<Option<String>, _>(idx) {
                     Ok(Some(v)) => write_str(buf, &v),
                     Ok(None) => write_nil(buf),

--- a/crates/oxyde-driver/src/convert/postgres.rs
+++ b/crates/oxyde-driver/src/convert/postgres.rs
@@ -7,12 +7,45 @@
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use oxyde_codec::ColumnTypeSpec;
 use rust_decimal::Decimal;
-use sqlx::{postgres::PgRow, Row};
+use sqlx::{
+    error::BoxDynError,
+    postgres::{PgHasArrayType, PgRow, PgTypeInfo, PgTypeKind, PgValueRef, Postgres},
+    Decode, Row, Type,
+};
 use uuid::Uuid;
 
 use super::encoder::*;
 
 pub struct PgEncoder;
+
+#[derive(Debug, Clone)]
+struct PgEnumText(String);
+
+impl Type<Postgres> for PgEnumText {
+    fn type_info() -> PgTypeInfo {
+        <String as Type<Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        <String as Type<Postgres>>::compatible(ty) || matches!(ty.kind(), PgTypeKind::Enum(_))
+    }
+}
+
+impl PgHasArrayType for PgEnumText {
+    fn array_type_info() -> PgTypeInfo {
+        <String as PgHasArrayType>::array_type_info()
+    }
+
+    fn array_compatible(ty: &PgTypeInfo) -> bool {
+        matches!(ty.kind(), PgTypeKind::Array(element) if Self::compatible(element))
+    }
+}
+
+impl<'r> Decode<'r, Postgres> for PgEnumText {
+    fn decode(value: PgValueRef<'r>) -> Result<Self, BoxDynError> {
+        Ok(Self(value.as_str()?.to_string()))
+    }
+}
 
 impl CellEncoder for PgEncoder {
     type Row = PgRow;
@@ -39,6 +72,14 @@ impl CellEncoder for PgEncoder {
             ColumnTypeSpec::Text | ColumnTypeSpec::String { .. } => {
                 match row.try_get::<Option<String>, _>(idx) {
                     Ok(Some(v)) => write_str(buf, &v),
+                    Ok(None) => write_nil(buf),
+                    Err(_) => write_nil(buf),
+                }
+                true
+            }
+            ColumnTypeSpec::Enum { .. } => {
+                match row.try_get::<Option<PgEnumText>, _>(idx) {
+                    Ok(Some(v)) => write_str(buf, &v.0),
                     Ok(None) => write_nil(buf),
                     Err(_) => write_nil(buf),
                 }
@@ -258,6 +299,9 @@ fn encode_pg_array(buf: &mut Vec<u8>, row: &PgRow, idx: usize, item: &ColumnType
         }
         ColumnTypeSpec::Text | ColumnTypeSpec::String { .. } => {
             encode_pg_array_ref::<String>(buf, row, idx, |b, v| write_str(b, v));
+        }
+        ColumnTypeSpec::Enum { .. } => {
+            encode_pg_array_ref::<PgEnumText>(buf, row, idx, |b, v| write_str(b, &v.0));
         }
         ColumnTypeSpec::Uuid => {
             encode_pg_array_ref::<Uuid>(buf, row, idx, |b, v| {

--- a/crates/oxyde-driver/src/convert/sqlite.rs
+++ b/crates/oxyde-driver/src/convert/sqlite.rs
@@ -32,6 +32,7 @@ impl CellEncoder for SqliteEncoder {
             // datetime, date, time, decimal, uuid — stored as TEXT in SQLite
             ColumnTypeSpec::Text
             | ColumnTypeSpec::String { .. }
+            | ColumnTypeSpec::Enum { .. }
             | ColumnTypeSpec::DateTime
             | ColumnTypeSpec::DateTimeUtc
             | ColumnTypeSpec::Date

--- a/crates/oxyde-migrate/src/diff.rs
+++ b/crates/oxyde-migrate/src/diff.rs
@@ -2,8 +2,9 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::op::MigrationOp;
+use crate::op::{EnumFieldRef, MigrationOp};
 use crate::types::{Dialect, MigrateError, Result, Snapshot, TableDef};
+use oxyde_codec::ColumnTypeSpec;
 use serde::{Deserialize, Serialize};
 
 /// Topologically sort table names so that referenced tables come before
@@ -86,6 +87,136 @@ fn topo_sort_table_names(tables: &HashMap<String, TableDef>) -> Result<Vec<Strin
     Ok(result)
 }
 
+fn collect_enum_defs(snapshot: &Snapshot) -> Result<HashMap<String, Vec<String>>> {
+    let mut defs = HashMap::new();
+    for table in snapshot.tables.values() {
+        for field in &table.fields {
+            collect_enum_def_from_spec(&field.column_type, &mut defs)?;
+        }
+    }
+    Ok(defs)
+}
+
+fn collect_enum_def_from_spec(
+    spec: &ColumnTypeSpec,
+    defs: &mut HashMap<String, Vec<String>>,
+) -> Result<()> {
+    match spec {
+        ColumnTypeSpec::Enum { name, values } => {
+            if let Some(existing) = defs.get(name) {
+                if existing != values {
+                    return Err(MigrateError::DiffError(format!(
+                        "enum type '{}' has conflicting value sets",
+                        name
+                    )));
+                }
+            } else {
+                defs.insert(name.clone(), values.clone());
+            }
+        }
+        ColumnTypeSpec::Array { item } => collect_enum_def_from_spec(item, defs)?,
+        _ => {}
+    }
+    Ok(())
+}
+
+fn sorted_keys(map: &HashMap<String, Vec<String>>) -> Vec<String> {
+    let mut keys = map.keys().cloned().collect::<Vec<_>>();
+    keys.sort();
+    keys
+}
+
+fn enum_values_are_append_only(old_values: &[String], new_values: &[String]) -> bool {
+    new_values.len() >= old_values.len() && &new_values[..old_values.len()] == old_values
+}
+
+fn column_type_requires_alter(old: &ColumnTypeSpec, new: &ColumnTypeSpec) -> bool {
+    match (old, new) {
+        (
+            ColumnTypeSpec::Enum { name: old_name, .. },
+            ColumnTypeSpec::Enum { name: new_name, .. },
+        ) => old_name != new_name,
+        (ColumnTypeSpec::Array { item: old_item }, ColumnTypeSpec::Array { item: new_item }) => {
+            column_type_requires_alter(old_item, new_item)
+        }
+        _ => old != new,
+    }
+}
+
+fn db_type_requires_alter(
+    old_type: &ColumnTypeSpec,
+    new_type: &ColumnTypeSpec,
+    old_db_type: &Option<String>,
+    new_db_type: &Option<String>,
+) -> bool {
+    if !column_type_requires_alter(old_type, new_type) && contains_enum_type(old_type) {
+        return false;
+    }
+    old_db_type != new_db_type
+}
+
+fn contains_enum_type(spec: &ColumnTypeSpec) -> bool {
+    match spec {
+        ColumnTypeSpec::Enum { .. } => true,
+        ColumnTypeSpec::Array { item } => contains_enum_type(item),
+        _ => false,
+    }
+}
+
+fn scalar_enum_name(spec: &ColumnTypeSpec) -> Option<&str> {
+    match spec {
+        ColumnTypeSpec::Enum { name, .. } => Some(name),
+        _ => None,
+    }
+}
+
+fn existing_scalar_enum_fields(
+    old: &Snapshot,
+    new: &Snapshot,
+    enum_name: &str,
+    values: &[String],
+) -> Vec<EnumFieldRef> {
+    let mut fields = Vec::new();
+    let mut table_names = old
+        .tables
+        .keys()
+        .filter(|name| new.tables.contains_key(*name))
+        .cloned()
+        .collect::<Vec<_>>();
+    table_names.sort();
+
+    for table_name in table_names {
+        let old_table = &old.tables[&table_name];
+        let new_table = &new.tables[&table_name];
+        for old_field in &old_table.fields {
+            if scalar_enum_name(&old_field.column_type) != Some(enum_name) {
+                continue;
+            }
+            if let Some(new_field) = new_table
+                .fields
+                .iter()
+                .find(|field| field.name == old_field.name)
+                .filter(|field| scalar_enum_name(&field.column_type) == Some(enum_name))
+            {
+                let mut field = new_field.clone();
+                if let ColumnTypeSpec::Enum {
+                    values: field_values,
+                    ..
+                } = &mut field.column_type
+                {
+                    *field_values = values.to_vec();
+                }
+                fields.push(EnumFieldRef {
+                    table: table_name.clone(),
+                    field,
+                });
+            }
+        }
+    }
+
+    fields
+}
+
 /// Migration file
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Migration {
@@ -124,19 +255,23 @@ impl Migration {
     /// This ensures referenced tables exist before FK constraints are added
     /// (PG/MySQL emit FK as separate ALTER TABLE, not inline in CREATE TABLE).
     pub fn to_sql(&self, dialect: Dialect) -> Result<Vec<String>> {
-        let mut all_sql = Vec::new();
+        let mut all_sql: Vec<(u8, String)> = Vec::new();
         for op in &self.operations {
             let sqls = op.to_sql(dialect)?;
-            all_sql.extend(sqls);
-        }
-        all_sql.sort_by_key(|s| {
-            if s.trim_start().starts_with("ALTER") {
-                1
-            } else {
-                0
+            for sql in sqls {
+                let bucket = match op {
+                    MigrationOp::CreateEnumType { .. } => 0,
+                    MigrationOp::AddEnumValue { .. } => 1,
+                    MigrationOp::DropEnumType { .. } => 4,
+                    MigrationOp::AlterEnumType { .. } => 5,
+                    _ if sql.trim_start().starts_with("ALTER TABLE") => 3,
+                    _ => 2,
+                };
+                all_sql.push((bucket, sql));
             }
-        });
-        Ok(all_sql)
+        }
+        all_sql.sort_by_key(|(bucket, _)| *bucket);
+        Ok(all_sql.into_iter().map(|(_, sql)| sql).collect())
     }
 }
 
@@ -147,6 +282,39 @@ impl Migration {
 /// Cycles among unchanged tables are irrelevant and pass through silently.
 pub fn compute_diff(old: &Snapshot, new: &Snapshot) -> Result<Vec<MigrationOp>> {
     let mut ops = Vec::new();
+    let old_enums = collect_enum_defs(old)?;
+    let new_enums = collect_enum_defs(new)?;
+
+    for name in sorted_keys(&new_enums) {
+        if !old_enums.contains_key(&name) {
+            ops.push(MigrationOp::CreateEnumType {
+                name: name.clone(),
+                values: new_enums[&name].clone(),
+            });
+        }
+    }
+
+    for name in sorted_keys(&new_enums) {
+        if let Some(old_values) = old_enums.get(&name) {
+            let new_values = &new_enums[&name];
+            if enum_values_are_append_only(old_values, new_values) {
+                for (index, value) in new_values[old_values.len()..].iter().cloned().enumerate() {
+                    let values = &new_values[..old_values.len() + index + 1];
+                    ops.push(MigrationOp::AddEnumValue {
+                        name: name.clone(),
+                        value,
+                        fields: existing_scalar_enum_fields(old, new, &name, values),
+                    });
+                }
+            } else {
+                ops.push(MigrationOp::AlterEnumType {
+                    name: name.clone(),
+                    old_values: old_values.clone(),
+                    new_values: new_values.clone(),
+                });
+            }
+        }
+    }
 
     // Topo-sort only the subset of tables that are actually being created.
     // FKs from this subset to tables that already exist in `old` are not
@@ -215,8 +383,14 @@ pub fn compute_diff(old: &Snapshot, new: &Snapshot) -> Result<Vec<MigrationOp>> 
                 if let Some(old_field) = old_table.fields.iter().find(|f| f.name == new_field.name)
                 {
                     // Check if type changed using column_type or db_type
-                    let type_changed = old_field.column_type != new_field.column_type
-                        || old_field.db_type != new_field.db_type;
+                    let type_changed =
+                        column_type_requires_alter(&old_field.column_type, &new_field.column_type)
+                            || db_type_requires_alter(
+                                &old_field.column_type,
+                                &new_field.column_type,
+                                &old_field.db_type,
+                                &new_field.db_type,
+                            );
 
                     let nullable_changed = old_field.nullable != new_field.nullable;
                     let default_changed = old_field.default != new_field.default;
@@ -347,6 +521,15 @@ pub fn compute_diff(old: &Snapshot, new: &Snapshot) -> Result<Vec<MigrationOp>> 
                     });
                 }
             }
+        }
+    }
+
+    for name in sorted_keys(&old_enums) {
+        if !new_enums.contains_key(&name) {
+            ops.push(MigrationOp::DropEnumType {
+                name: name.clone(),
+                values: Some(old_enums[&name].clone()),
+            });
         }
     }
 

--- a/crates/oxyde-migrate/src/op.rs
+++ b/crates/oxyde-migrate/src/op.rs
@@ -3,10 +3,36 @@
 use crate::types::{CheckDef, FieldDef, ForeignKeyDef, IndexDef, TableDef};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnumFieldRef {
+    pub table: String,
+    pub field: FieldDef,
+}
+
 /// Migration operation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum MigrationOp {
+    CreateEnumType {
+        name: String,
+        values: Vec<String>,
+    },
+    DropEnumType {
+        name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        values: Option<Vec<String>>,
+    },
+    AddEnumValue {
+        name: String,
+        value: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        fields: Vec<EnumFieldRef>,
+    },
+    AlterEnumType {
+        name: String,
+        old_values: Vec<String>,
+        new_values: Vec<String>,
+    },
     CreateTable {
         table: TableDef,
     },

--- a/crates/oxyde-migrate/src/spec_sql.rs
+++ b/crates/oxyde-migrate/src/spec_sql.rs
@@ -27,10 +27,21 @@ pub fn resolve_spec_type(
     dialect: Dialect,
     is_pk: bool,
 ) -> String {
+    if contains_enum_spec(spec) {
+        return canonical_type(spec, dialect, is_pk);
+    }
     if let Some(db_type) = db_type {
         return translate_user_db_type(db_type, dialect);
     }
     canonical_type(spec, dialect, is_pk)
+}
+
+fn contains_enum_spec(spec: &ColumnTypeSpec) -> bool {
+    match spec {
+        ColumnTypeSpec::Enum { .. } => true,
+        ColumnTypeSpec::Array { item } => contains_enum_spec(item),
+        _ => false,
+    }
 }
 
 /// SERIAL/BIGSERIAL are PostgreSQL-specific — translate for other dialects.
@@ -117,6 +128,18 @@ fn canonical_type(spec: &ColumnTypeSpec, dialect: Dialect, is_pk: bool) -> Strin
             D::Mysql => "JSON".to_string(),
             D::Sqlite => "TEXT".to_string(),
         },
+        S::Enum { name, values } => match dialect {
+            D::Postgres => quote_postgres_type_name(name),
+            D::Mysql => format!(
+                "ENUM({})",
+                values
+                    .iter()
+                    .map(|value| quote_sql_string(value))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            ),
+            D::Sqlite => "TEXT".to_string(),
+        },
         S::Array { item } => match dialect {
             D::Postgres => format!("{}[]", canonical_type(item, dialect, false)),
             D::Mysql => "JSON".to_string(),
@@ -124,6 +147,17 @@ fn canonical_type(spec: &ColumnTypeSpec, dialect: Dialect, is_pk: bool) -> Strin
         },
         S::Unknown => "TEXT".to_string(),
     }
+}
+
+pub(crate) fn quote_postgres_type_name(name: &str) -> String {
+    name.split('.')
+        .map(|part| format!("\"{}\"", part.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+pub(crate) fn quote_sql_string(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
 }
 
 #[cfg(test)]
@@ -239,6 +273,26 @@ mod tests {
         assert_eq!(
             resolve_spec_type(&spec, Some("SERIAL"), Dialect::Postgres, false),
             "SERIAL"
+        );
+    }
+
+    #[test]
+    fn enum_type_rendering() {
+        let spec = ColumnTypeSpec::Enum {
+            name: "post_status_enum".to_string(),
+            values: vec!["draft".to_string(), "published".to_string()],
+        };
+        assert_eq!(
+            resolve_spec_type(&spec, None, Dialect::Postgres, false),
+            r#""post_status_enum""#
+        );
+        assert_eq!(
+            resolve_spec_type(&spec, None, Dialect::Mysql, false),
+            "ENUM('draft','published')"
+        );
+        assert_eq!(
+            resolve_spec_type(&spec, None, Dialect::Sqlite, false),
+            "TEXT"
         );
     }
 

--- a/crates/oxyde-migrate/src/sql.rs
+++ b/crates/oxyde-migrate/src/sql.rs
@@ -263,6 +263,61 @@ impl MigrationOp {
     /// (e.g., ALTER COLUMN on SQLite without table schema).
     pub fn to_sql(&self, dialect: Dialect) -> Result<Vec<String>> {
         match self {
+            MigrationOp::CreateEnumType { name, values } => {
+                if dialect != Dialect::Postgres {
+                    return Ok(Vec::new());
+                }
+                let labels = values
+                    .iter()
+                    .map(|value| crate::spec_sql::quote_sql_string(value))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Ok(vec![format!(
+                    "CREATE TYPE {} AS ENUM ({})",
+                    crate::spec_sql::quote_postgres_type_name(name),
+                    labels
+                )])
+            }
+
+            MigrationOp::DropEnumType { name, values: _ } => {
+                if dialect != Dialect::Postgres {
+                    return Ok(Vec::new());
+                }
+                Ok(vec![format!(
+                    "DROP TYPE {}",
+                    crate::spec_sql::quote_postgres_type_name(name)
+                )])
+            }
+
+            MigrationOp::AddEnumValue {
+                name,
+                value,
+                fields,
+            } => {
+                if dialect == Dialect::Mysql {
+                    return Ok(fields
+                        .iter()
+                        .map(|field| {
+                            format!(
+                                "ALTER TABLE `{}` MODIFY COLUMN {}",
+                                field.table,
+                                mysql_column_def(&field.field)
+                            )
+                        })
+                        .collect());
+                }
+                if dialect == Dialect::Sqlite {
+                    return Ok(Vec::new());
+                }
+                Ok(vec![format!(
+                    "ALTER TYPE {} ADD VALUE IF NOT EXISTS {}",
+                    crate::spec_sql::quote_postgres_type_name(name),
+                    crate::spec_sql::quote_sql_string(value)
+                )])
+            }
+
+            MigrationOp::AlterEnumType { .. } => Ok(Vec::new()),
+
             MigrationOp::CreateTable { table } => {
                 let mut create = SeaTable::create();
                 create.table(Alias::new(&table.name));

--- a/crates/oxyde-migrate/tests/migration_tests.rs
+++ b/crates/oxyde-migrate/tests/migration_tests.rs
@@ -4,8 +4,8 @@
 
 use oxyde_codec::ColumnTypeSpec;
 use oxyde_migrate::{
-    compute_diff, CheckDef, Dialect, FieldDef, ForeignKeyDef, IndexDef, MigrationOp, Snapshot,
-    TableDef,
+    compute_diff, CheckDef, Dialect, FieldDef, ForeignKeyDef, IndexDef, Migration, MigrationOp,
+    Snapshot, TableDef,
 };
 
 fn sample_field(name: &str) -> FieldDef {
@@ -53,6 +53,51 @@ fn sample_table() -> TableDef {
         foreign_keys: vec![],
         checks: vec![],
         comment: Some("User accounts".into()),
+    }
+}
+
+fn enum_spec(values: &[&str]) -> ColumnTypeSpec {
+    ColumnTypeSpec::Enum {
+        name: "post_status_enum".into(),
+        values: values.iter().map(|value| (*value).into()).collect(),
+    }
+}
+
+fn enum_table(values: &[&str]) -> TableDef {
+    TableDef {
+        name: "posts".into(),
+        fields: vec![
+            FieldDef {
+                name: "id".into(),
+                column_type: ColumnTypeSpec::BigInteger,
+                db_type: None,
+                nullable: false,
+                primary_key: true,
+                unique: false,
+                default: None,
+                auto_increment: false,
+                max_length: None,
+                max_digits: None,
+                decimal_places: None,
+            },
+            FieldDef {
+                name: "status".into(),
+                column_type: enum_spec(values),
+                db_type: None,
+                nullable: false,
+                primary_key: false,
+                unique: false,
+                default: None,
+                auto_increment: false,
+                max_length: None,
+                max_digits: None,
+                decimal_places: None,
+            },
+        ],
+        indexes: vec![],
+        foreign_keys: vec![],
+        checks: vec![],
+        comment: None,
     }
 }
 
@@ -120,6 +165,170 @@ fn test_migration_create_table_generates_sql() {
 
     assert!(sql[0].contains(r#"CREATE TABLE "users""#));
     assert!(sql[1].contains(r#"CREATE UNIQUE INDEX "users_email_idx""#));
+}
+
+#[test]
+fn test_postgres_enum_type_is_created_before_table() {
+    let migration = Migration {
+        name: "enum".into(),
+        operations: vec![
+            MigrationOp::CreateEnumType {
+                name: "post_status_enum".into(),
+                values: vec!["draft".into(), "published".into()],
+            },
+            MigrationOp::CreateTable {
+                table: enum_table(&["draft", "published"]),
+            },
+        ],
+    };
+
+    let sql = migration.to_sql(Dialect::Postgres).unwrap();
+    assert_eq!(
+        sql[0],
+        r#"CREATE TYPE "post_status_enum" AS ENUM ('draft', 'published')"#
+    );
+    assert!(
+        sql[1].contains(r#""status" "post_status_enum" NOT NULL"#),
+        "{}",
+        sql[1]
+    );
+}
+
+#[test]
+fn test_mysql_enum_is_inline_column_type() {
+    let sql = MigrationOp::CreateTable {
+        table: enum_table(&["draft", "published"]),
+    }
+    .to_sql(Dialect::Mysql)
+    .unwrap();
+
+    assert!(sql[0].contains("`status` ENUM('draft','published') NOT NULL"));
+}
+
+#[test]
+fn test_compute_diff_adds_enum_value_without_altering_column() {
+    let mut old = Snapshot::new();
+    old.add_table(enum_table(&["draft", "published"]));
+    let mut new = Snapshot::new();
+    new.add_table(enum_table(&["draft", "published", "archived"]));
+
+    let ops = compute_diff(&old, &new).unwrap();
+    assert_eq!(ops.len(), 1);
+    match &ops[0] {
+        MigrationOp::AddEnumValue {
+            name,
+            value,
+            fields,
+        } => {
+            assert_eq!(name, "post_status_enum");
+            assert_eq!(value, "archived");
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].table, "posts");
+            assert_eq!(fields[0].field.name, "status");
+        }
+        op => panic!("expected AddEnumValue, got {:?}", op),
+    }
+}
+
+#[test]
+fn test_mysql_enum_value_append_modifies_inline_enum_columns() {
+    let mut old = Snapshot::new();
+    old.add_table(enum_table(&["draft", "published"]));
+    let mut new = Snapshot::new();
+    new.add_table(enum_table(&["draft", "published", "archived"]));
+
+    let ops = compute_diff(&old, &new).unwrap();
+    let migration = Migration {
+        name: "enum_value".into(),
+        operations: ops,
+    };
+
+    let sql = migration.to_sql(Dialect::Mysql).unwrap();
+    assert_eq!(sql.len(), 1);
+    assert_eq!(
+        sql[0],
+        "ALTER TABLE `posts` MODIFY COLUMN `status` ENUM('draft','published','archived') NOT NULL"
+    );
+}
+
+#[test]
+fn test_mysql_multiple_enum_value_append_modifies_inline_enum_columns_progressively() {
+    let mut old = Snapshot::new();
+    old.add_table(enum_table(&["draft", "published"]));
+    let mut new = Snapshot::new();
+    new.add_table(enum_table(&["draft", "published", "archived", "deleted"]));
+
+    let ops = compute_diff(&old, &new).unwrap();
+    let migration = Migration {
+        name: "enum_value".into(),
+        operations: ops,
+    };
+
+    let sql = migration.to_sql(Dialect::Mysql).unwrap();
+    assert_eq!(
+        sql,
+        vec![
+            "ALTER TABLE `posts` MODIFY COLUMN `status` ENUM('draft','published','archived') NOT NULL",
+            "ALTER TABLE `posts` MODIFY COLUMN `status` ENUM('draft','published','archived','deleted') NOT NULL",
+        ]
+    );
+}
+
+#[test]
+fn test_postgres_enum_value_is_added_before_dependent_ddl() {
+    let migration = Migration {
+        name: "enum_value".into(),
+        operations: vec![
+            MigrationOp::CreateIndex {
+                table: "posts".into(),
+                index: IndexDef {
+                    name: "posts_archived_idx".into(),
+                    fields: vec!["status".into()],
+                    unique: false,
+                    method: Some("btree".into()),
+                    where_clause: Some("status = 'archived'".into()),
+                },
+            },
+            MigrationOp::AddEnumValue {
+                name: "post_status_enum".into(),
+                value: "archived".into(),
+                fields: vec![],
+            },
+        ],
+    };
+
+    let sql = migration.to_sql(Dialect::Postgres).unwrap();
+    assert_eq!(
+        sql[0],
+        r#"ALTER TYPE "post_status_enum" ADD VALUE IF NOT EXISTS 'archived'"#
+    );
+    assert!(sql[1].contains(r#"CREATE INDEX "posts_archived_idx""#));
+}
+
+#[test]
+fn test_compute_diff_emits_manual_enum_alter_for_value_removal() {
+    let mut old = Snapshot::new();
+    old.add_table(enum_table(&["draft", "published"]));
+    let mut new = Snapshot::new();
+    new.add_table(enum_table(&["draft"]));
+
+    let ops = compute_diff(&old, &new).unwrap();
+    assert_eq!(ops.len(), 1);
+    match &ops[0] {
+        MigrationOp::AlterEnumType {
+            name,
+            old_values,
+            new_values,
+        } => {
+            assert_eq!(name, "post_status_enum");
+            assert_eq!(
+                old_values,
+                &vec!["draft".to_string(), "published".to_string()]
+            );
+            assert_eq!(new_values, &vec!["draft".to_string()]);
+        }
+        op => panic!("expected AlterEnumType, got {:?}", op),
+    }
 }
 
 #[test]

--- a/crates/oxyde-query/src/builder/bulk.rs
+++ b/crates/oxyde-query/src/builder/bulk.rs
@@ -10,7 +10,7 @@ use sea_query::{
 
 use crate::error::{QueryError, Result};
 use crate::filter::build_filter_node;
-use crate::utils::{bind_value, ColumnIdent, TableIdent};
+use crate::utils::{bind_value, typed_value_expr, ColumnIdent, TableIdent};
 use crate::Dialect;
 
 /// Build bulk UPDATE query using CASE WHEN statements.
@@ -45,7 +45,7 @@ pub fn build_bulk_update(
         for column in row.values.keys() {
             update_columns.insert(column.clone());
         }
-        let cond = build_bulk_row_condition(row, col_types)?;
+        let cond = build_bulk_row_condition(row, col_types, dialect)?;
         row_conditions.push(cond);
     }
 
@@ -66,7 +66,10 @@ pub fn build_bulk_update(
             .unwrap_or(&ColumnTypeSpec::Unknown);
         for (row, cond) in bulk.rows.iter().zip(&row_conditions) {
             if let Some(value) = row.values.get(&column) {
-                case_stmt = case_stmt.case(cond.clone(), Expr::val(bind_value(value, spec)));
+                case_stmt = case_stmt.case(
+                    cond.clone(),
+                    typed_value_expr(bind_value(value, spec), spec, dialect),
+                );
             }
         }
         // ELSE keeps current value for rows not matched by this column
@@ -82,7 +85,7 @@ pub fn build_bulk_update(
     query.cond_where(filter_cond);
 
     if let Some(filter_tree) = &ir.filter_tree {
-        let expr = build_filter_node(filter_tree, None, col_types, None)?;
+        let expr = build_filter_node(filter_tree, None, col_types, None, dialect)?;
         query.and_where(expr);
     }
 
@@ -103,10 +106,11 @@ pub fn build_bulk_update(
 fn build_bulk_row_condition(
     row: &BulkUpdateRow,
     col_types: Option<&HashMap<String, ColumnTypeSpec>>,
+    dialect: Dialect,
 ) -> Result<Cond> {
     let mut cond = Cond::all();
     for (column, value) in &row.filters {
-        cond = cond.add(build_match_expression(column, value, col_types));
+        cond = cond.add(build_match_expression(column, value, col_types, dialect));
     }
     Ok(cond)
 }
@@ -116,6 +120,7 @@ fn build_match_expression(
     column: &str,
     value: &rmpv::Value,
     col_types: Option<&HashMap<String, ColumnTypeSpec>>,
+    dialect: Dialect,
 ) -> SimpleExpr {
     if value.is_nil() {
         Expr::col(ColumnIdent(column.to_string())).is_null()
@@ -123,6 +128,10 @@ fn build_match_expression(
         let spec = col_types
             .and_then(|ct| ct.get(column))
             .unwrap_or(&ColumnTypeSpec::Unknown);
-        Expr::col(ColumnIdent(column.to_string())).eq(bind_value(value, spec))
+        Expr::col(ColumnIdent(column.to_string())).eq(typed_value_expr(
+            bind_value(value, spec),
+            spec,
+            dialect,
+        ))
     }
 }

--- a/crates/oxyde-query/src/builder/delete.rs
+++ b/crates/oxyde-query/src/builder/delete.rs
@@ -16,7 +16,7 @@ pub fn build_delete(ir: &QueryIR, dialect: Dialect) -> Result<(String, Vec<Value
 
     // Add filters (no JOIN in DELETE, so no table qualification needed)
     if let Some(filter_tree) = &ir.filter_tree {
-        let expr = build_filter_node(filter_tree, None, ir.column_types.as_ref(), None)?;
+        let expr = build_filter_node(filter_tree, None, ir.column_types.as_ref(), None, dialect)?;
         query.and_where(expr);
     }
 

--- a/crates/oxyde-query/src/builder/insert.rs
+++ b/crates/oxyde-query/src/builder/insert.rs
@@ -6,7 +6,7 @@ use sea_query::{
 };
 
 use crate::error::{QueryError, Result};
-use crate::utils::{bind_value, rmpv_to_simple_expr, ColumnIdent, TableIdent};
+use crate::utils::{bind_value, rmpv_to_simple_expr, typed_value_expr, ColumnIdent, TableIdent};
 use crate::Dialect;
 
 /// Build INSERT query from QueryIR
@@ -33,7 +33,8 @@ pub fn build_insert(ir: &QueryIR, dialect: Dialect) -> Result<(String, Vec<Value
             if let Some(expr) = rmpv_to_simple_expr(val)? {
                 vals.push(expr);
             } else {
-                vals.push(Expr::val(bind_value(val, get_spec(col))).into());
+                let spec = get_spec(col);
+                vals.push(typed_value_expr(bind_value(val, spec), spec, dialect));
             }
         }
 
@@ -69,7 +70,8 @@ pub fn build_insert(ir: &QueryIR, dialect: Dialect) -> Result<(String, Vec<Value
                 if let Some(expr) = rmpv_to_simple_expr(val)? {
                     vals.push(expr);
                 } else {
-                    vals.push(Expr::val(bind_value(val, get_spec(&col.0))).into());
+                    let spec = get_spec(&col.0);
+                    vals.push(typed_value_expr(bind_value(val, spec), spec, dialect));
                 }
             }
             query.values(vals)?;
@@ -114,9 +116,10 @@ pub fn build_insert(ir: &QueryIR, dialect: Dialect) -> Result<(String, Vec<Value
                             if let Some(expr) = rmpv_to_simple_expr(val)? {
                                 conflict.value(ColumnIdent(col.clone()), expr);
                             } else {
+                                let spec = get_spec(col);
                                 conflict.value(
                                     ColumnIdent(col.clone()),
-                                    Expr::val(bind_value(val, get_spec(col))),
+                                    typed_value_expr(bind_value(val, spec), spec, dialect),
                                 );
                             }
                         }
@@ -173,9 +176,10 @@ pub fn build_insert(ir: &QueryIR, dialect: Dialect) -> Result<(String, Vec<Value
                             if let Some(expr) = rmpv_to_simple_expr(val)? {
                                 conflict.value(ColumnIdent(col.clone()), expr);
                             } else {
+                                let spec = get_spec(col);
                                 conflict.value(
                                     ColumnIdent(col.clone()),
-                                    Expr::val(bind_value(val, get_spec(col))),
+                                    typed_value_expr(bind_value(val, spec), spec, dialect),
                                 );
                             }
                         }

--- a/crates/oxyde-query/src/builder/select.rs
+++ b/crates/oxyde-query/src/builder/select.rs
@@ -14,7 +14,7 @@ use crate::Dialect;
 
 /// Build a `SelectStatement` from QueryIR (without serializing to string).
 /// Used recursively for UNION sub-queries.
-fn build_select_statement(ir: &QueryIR) -> Result<SelectStatement> {
+fn build_select_statement(ir: &QueryIR, dialect: Dialect) -> Result<SelectStatement> {
     let table = TableIdent(ir.table.clone());
     let mut query = Query::select();
     query.from(table.clone());
@@ -61,7 +61,13 @@ fn build_select_statement(ir: &QueryIR) -> Result<SelectStatement> {
     };
 
     if let Some(filter_tree) = &ir.filter_tree {
-        let expr = build_filter_node(filter_tree, default_table, ir.column_types.as_ref(), None)?;
+        let expr = build_filter_node(
+            filter_tree,
+            default_table,
+            ir.column_types.as_ref(),
+            None,
+            dialect,
+        )?;
         query.and_where(expr);
     }
 
@@ -85,6 +91,7 @@ fn build_select_statement(ir: &QueryIR) -> Result<SelectStatement> {
             default_table,
             ir.column_types.as_ref(),
             ir.aggregates.as_deref(),
+            dialect,
         )?;
         query.and_having(expr);
     }
@@ -95,7 +102,7 @@ fn build_select_statement(ir: &QueryIR) -> Result<SelectStatement> {
 
     // UNION via sea-query (recursive)
     if let Some(union_query_ir) = &ir.union_query {
-        let union_stmt = build_select_statement(union_query_ir)?;
+        let union_stmt = build_select_statement(union_query_ir, dialect)?;
         let union_type = if ir.union_all.unwrap_or(false) {
             UnionType::All
         } else {
@@ -172,8 +179,13 @@ pub fn build_select(ir: &QueryIR, dialect: Dialect) -> Result<(String, Vec<Value
         };
 
         if let Some(filter_tree) = &ir.filter_tree {
-            let expr =
-                build_filter_node(filter_tree, default_table, ir.column_types.as_ref(), None)?;
+            let expr = build_filter_node(
+                filter_tree,
+                default_table,
+                ir.column_types.as_ref(),
+                None,
+                dialect,
+            )?;
             count_query.and_where(expr);
         }
 
@@ -184,7 +196,7 @@ pub fn build_select(ir: &QueryIR, dialect: Dialect) -> Result<(String, Vec<Value
         return Ok(build_query_string(count_query, dialect));
     }
 
-    let query = build_select_statement(ir)?;
+    let query = build_select_statement(ir, dialect)?;
     let (sql, values) = build_query_string(query, dialect);
 
     if ir.exists.unwrap_or(false) {

--- a/crates/oxyde-query/src/builder/update.rs
+++ b/crates/oxyde-query/src/builder/update.rs
@@ -1,11 +1,11 @@
 //! UPDATE query building
 
 use oxyde_codec::{ColumnTypeSpec, QueryIR};
-use sea_query::{Expr, MysqlQueryBuilder, PostgresQueryBuilder, Query, SqliteQueryBuilder, Value};
+use sea_query::{MysqlQueryBuilder, PostgresQueryBuilder, Query, SqliteQueryBuilder, Value};
 
 use crate::error::Result;
 use crate::filter::build_filter_node;
-use crate::utils::{bind_value, rmpv_to_simple_expr, ColumnIdent, TableIdent};
+use crate::utils::{bind_value, rmpv_to_simple_expr, typed_value_expr, ColumnIdent, TableIdent};
 use crate::Dialect;
 
 /// Build UPDATE query from QueryIR
@@ -32,9 +32,10 @@ pub fn build_update(ir: &QueryIR, dialect: Dialect) -> Result<(String, Vec<Value
             if let Some(expr) = rmpv_to_simple_expr(val)? {
                 query.value(ColumnIdent(col.clone()), expr);
             } else {
+                let spec = get_spec(col);
                 query.value(
                     ColumnIdent(col.clone()),
-                    Expr::val(bind_value(val, get_spec(col))),
+                    typed_value_expr(bind_value(val, spec), spec, dialect),
                 );
             }
         }
@@ -42,7 +43,7 @@ pub fn build_update(ir: &QueryIR, dialect: Dialect) -> Result<(String, Vec<Value
 
     // Add filters (no JOIN in UPDATE, so no table qualification needed)
     if let Some(filter_tree) = &ir.filter_tree {
-        let expr = build_filter_node(filter_tree, None, ir.column_types.as_ref(), None)?;
+        let expr = build_filter_node(filter_tree, None, ir.column_types.as_ref(), None, dialect)?;
         query.and_where(expr);
     }
 

--- a/crates/oxyde-query/src/filter/expression.rs
+++ b/crates/oxyde-query/src/filter/expression.rs
@@ -37,6 +37,9 @@ fn resolve_col_spec<'a>(
     col_name: &str,
     col_types: Option<&'a HashMap<String, ColumnTypeSpec>>,
 ) -> &'a ColumnTypeSpec {
+    if let Some(spec) = col_types.and_then(|ct| ct.get(col_name)) {
+        return spec;
+    }
     let col_key = col_name.rsplit('.').next().unwrap_or(col_name);
     col_types
         .and_then(|ct| ct.get(col_key))

--- a/crates/oxyde-query/src/filter/expression.rs
+++ b/crates/oxyde-query/src/filter/expression.rs
@@ -3,11 +3,12 @@
 use std::collections::HashMap;
 
 use oxyde_codec::{Aggregate, ColumnTypeSpec, Filter, FilterNode};
-use sea_query::{Expr, Func, LikeExpr, SimpleExpr, Value};
+use sea_query::{Expr, Func, LikeExpr, SimpleExpr};
 
 use crate::aggregate::build_aggregate;
 use crate::error::{QueryError, Result};
-use crate::utils::{bind_value, ColumnIdent, TableIdent};
+use crate::utils::{bind_value, typed_value_expr, ColumnIdent, TableIdent};
+use crate::Dialect;
 
 /// Create column expression, handling "table.column" format for joins
 /// If default_table is provided and column is not already qualified, prepend it
@@ -67,19 +68,28 @@ pub fn build_filter_node(
     default_table: Option<&str>,
     col_types: Option<&HashMap<String, ColumnTypeSpec>>,
     aggregates: Option<&[Aggregate]>,
+    dialect: Dialect,
 ) -> Result<SimpleExpr> {
     match node {
-        FilterNode::Condition(filter) => apply_filter(filter, default_table, col_types, aggregates),
+        FilterNode::Condition(filter) => {
+            apply_filter(filter, default_table, col_types, aggregates, dialect)
+        }
         FilterNode::And { conditions } => {
             if conditions.is_empty() {
                 return Err(QueryError::InvalidQuery(
                     "AND node must have at least one condition".into(),
                 ));
             }
-            let first = build_filter_node(&conditions[0], default_table, col_types, aggregates)?;
+            let first = build_filter_node(
+                &conditions[0],
+                default_table,
+                col_types,
+                aggregates,
+                dialect,
+            )?;
             let mut result = first;
             for cond in &conditions[1..] {
-                let next = build_filter_node(cond, default_table, col_types, aggregates)?;
+                let next = build_filter_node(cond, default_table, col_types, aggregates, dialect)?;
                 result = result.and(next);
             }
             Ok(result)
@@ -90,16 +100,23 @@ pub fn build_filter_node(
                     "OR node must have at least one condition".into(),
                 ));
             }
-            let first = build_filter_node(&conditions[0], default_table, col_types, aggregates)?;
+            let first = build_filter_node(
+                &conditions[0],
+                default_table,
+                col_types,
+                aggregates,
+                dialect,
+            )?;
             let mut result = first;
             for cond in &conditions[1..] {
-                let next = build_filter_node(cond, default_table, col_types, aggregates)?;
+                let next = build_filter_node(cond, default_table, col_types, aggregates, dialect)?;
                 result = result.or(next);
             }
             Ok(result)
         }
         FilterNode::Not { condition } => {
-            let inner = build_filter_node(condition, default_table, col_types, aggregates)?;
+            let inner =
+                build_filter_node(condition, default_table, col_types, aggregates, dialect)?;
             Ok(inner.not())
         }
     }
@@ -113,6 +130,7 @@ fn apply_filter(
     default_table: Option<&str>,
     col_types: Option<&HashMap<String, ColumnTypeSpec>>,
     aggregates: Option<&[Aggregate]>,
+    dialect: Dialect,
 ) -> Result<SimpleExpr> {
     let col_name = filter.column.as_ref().unwrap_or(&filter.field);
 
@@ -130,12 +148,12 @@ fn apply_filter(
     let val = bind_value(&filter.value, spec);
 
     let expr = match filter.operator.as_str() {
-        "=" => col.eq(val),
-        "!=" => col.ne(val),
-        ">" => col.gt(val),
-        ">=" => col.gte(val),
-        "<" => col.lt(val),
-        "<=" => col.lte(val),
+        "=" => col.eq(typed_value_expr(val, spec, dialect)),
+        "!=" => col.ne(typed_value_expr(val, spec, dialect)),
+        ">" => col.gt(typed_value_expr(val, spec, dialect)),
+        ">=" => col.gte(typed_value_expr(val, spec, dialect)),
+        "<" => col.lt(typed_value_expr(val, spec, dialect)),
+        "<=" => col.lte(typed_value_expr(val, spec, dialect)),
         "LIKE" => {
             let text = filter.value.as_str().ok_or_else(|| {
                 QueryError::InvalidQuery("LIKE operator requires string value".into())
@@ -152,7 +170,10 @@ fn apply_filter(
         }
         "IN" => {
             if let rmpv::Value::Array(arr) = &filter.value {
-                let values: Vec<Value> = arr.iter().map(|v| bind_value(v, spec)).collect();
+                let values: Vec<SimpleExpr> = arr
+                    .iter()
+                    .map(|v| typed_value_expr(bind_value(v, spec), spec, dialect))
+                    .collect();
                 col.is_in(values)
             } else {
                 return Err(QueryError::InvalidQuery(
@@ -167,8 +188,8 @@ fn apply_filter(
                         "BETWEEN operator requires exactly two values".to_string(),
                     ));
                 }
-                let start = Expr::val(bind_value(&arr[0], spec));
-                let end = Expr::val(bind_value(&arr[1], spec));
+                let start = typed_value_expr(bind_value(&arr[0], spec), spec, dialect);
+                let end = typed_value_expr(bind_value(&arr[1], spec), spec, dialect);
                 col.between(start, end)
             } else {
                 return Err(QueryError::InvalidQuery(

--- a/crates/oxyde-query/src/lib.rs
+++ b/crates/oxyde-query/src/lib.rs
@@ -256,6 +256,25 @@ mod tests {
     }
 
     #[test]
+    fn test_qualified_filter_enum_value_is_cast_on_postgres() {
+        let ir = QueryIR {
+            table: "posts".into(),
+            cols: Some(vec!["id".into()]),
+            filter_tree: Some(filter_with_column(
+                "status",
+                "author.status",
+                "=",
+                rmpv_str("draft"),
+            )),
+            column_types: Some(HashMap::from([("author.status".into(), enum_spec())])),
+            ..Default::default()
+        };
+        let (sql, params) = build_sql(&ir, Dialect::Postgres).unwrap();
+        assert!(sql.contains("$1::\"post_status_enum\""), "{sql}");
+        assert_eq!(params.len(), 1);
+    }
+
+    #[test]
     fn test_mysql_placeholders() {
         let ir = QueryIR {
             table: "widgets".into(),

--- a/crates/oxyde-query/src/lib.rs
+++ b/crates/oxyde-query/src/lib.rs
@@ -121,7 +121,8 @@ pub fn build_sql(ir: &QueryIR, dialect: Dialect) -> Result<(String, Vec<Value>)>
 mod tests {
     use super::*;
     use oxyde_codec::{
-        ConflictAction, Filter, FilterNode, JoinColumn, JoinSpec, OnConflict, Operation, QueryIR,
+        ColumnTypeSpec, ConflictAction, Filter, FilterNode, JoinColumn, JoinSpec, OnConflict,
+        Operation, QueryIR,
     };
     use std::collections::HashMap;
 
@@ -139,6 +140,13 @@ mod tests {
 
     fn rmpv_arr(vals: Vec<rmpv::Value>) -> rmpv::Value {
         rmpv::Value::Array(vals)
+    }
+
+    fn enum_spec() -> ColumnTypeSpec {
+        ColumnTypeSpec::Enum {
+            name: "post_status_enum".into(),
+            values: vec!["draft".into(), "published".into()],
+        }
     }
 
     /// Helper to create a simple condition filter node
@@ -212,6 +220,39 @@ mod tests {
             Value::BigInt(Some(v)) => assert_eq!(*v, 42),
             other => panic!("unexpected param value: {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_insert_enum_value_is_cast_on_postgres() {
+        let ir = QueryIR {
+            op: Operation::Insert,
+            table: "posts".into(),
+            values: Some(HashMap::from([("status".into(), rmpv_str("draft"))])),
+            column_types: Some(HashMap::from([("status".into(), enum_spec())])),
+            ..Default::default()
+        };
+        let (sql, params) = build_sql(&ir, Dialect::Postgres).unwrap();
+        assert!(sql.contains("$1::\"post_status_enum\""), "{sql}");
+        assert_eq!(params.len(), 1);
+    }
+
+    #[test]
+    fn test_filter_enum_in_values_are_cast_on_postgres() {
+        let ir = QueryIR {
+            table: "posts".into(),
+            cols: Some(vec!["id".into()]),
+            filter_tree: Some(filter_cond(
+                "status",
+                "IN",
+                rmpv_arr(vec![rmpv_str("draft"), rmpv_str("published")]),
+            )),
+            column_types: Some(HashMap::from([("status".into(), enum_spec())])),
+            ..Default::default()
+        };
+        let (sql, params) = build_sql(&ir, Dialect::Postgres).unwrap();
+        assert!(sql.contains("$1::\"post_status_enum\""), "{sql}");
+        assert!(sql.contains("$2::\"post_status_enum\""), "{sql}");
+        assert_eq!(params.len(), 2);
     }
 
     #[test]

--- a/crates/oxyde-query/src/utils/bind.rs
+++ b/crates/oxyde-query/src/utils/bind.rs
@@ -12,8 +12,10 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use oxyde_codec::ColumnTypeSpec;
 use rust_decimal::Decimal;
 use sea_query::value::ArrayType;
-use sea_query::Value;
+use sea_query::{Expr, SimpleExpr, Value};
 use uuid::Uuid;
+
+use crate::Dialect;
 
 /// Convert an rmpv value without a column spec (raw SQL parameters).
 /// Identical to `bind_value(value, &ColumnTypeSpec::Unknown)`.
@@ -70,6 +72,15 @@ pub fn bind_value(value: &rmpv::Value, spec: &ColumnTypeSpec) -> Value {
     }
 }
 
+pub fn typed_value_expr(value: Value, spec: &ColumnTypeSpec, dialect: Dialect) -> SimpleExpr {
+    if dialect == Dialect::Postgres {
+        if let Some(type_name) = postgres_enum_cast_type(spec) {
+            return Expr::cust_with_values(format!("$1::{type_name}"), vec![value]);
+        }
+    }
+    Expr::val(value).into()
+}
+
 /// Bind a string payload according to the spec.
 ///
 /// Temporal specs and `Unknown` fall back to the RFC3339 heuristic on parse
@@ -120,6 +131,7 @@ fn bind_string(s: &str, spec: &ColumnTypeSpec) -> Value {
                 Err(_) => string_value(s),
             }
         }
+        ColumnTypeSpec::Enum { .. } => string_value(s),
         // Known non-temporal specs: definitely not a datetime — no heuristic.
         ColumnTypeSpec::BigInteger
         | ColumnTypeSpec::Double
@@ -139,7 +151,9 @@ fn typed_null(spec: &ColumnTypeSpec) -> Value {
         ColumnTypeSpec::BigInteger | ColumnTypeSpec::Timedelta => Value::BigInt(None),
         ColumnTypeSpec::Double => Value::Double(None),
         ColumnTypeSpec::Boolean => Value::Bool(None),
-        ColumnTypeSpec::Text | ColumnTypeSpec::String { .. } => Value::String(None),
+        ColumnTypeSpec::Text | ColumnTypeSpec::String { .. } | ColumnTypeSpec::Enum { .. } => {
+            Value::String(None)
+        }
         ColumnTypeSpec::Blob => Value::Bytes(None),
         ColumnTypeSpec::DateTime => Value::ChronoDateTime(None),
         ColumnTypeSpec::DateTimeUtc => Value::ChronoDateTimeUtc(None),
@@ -163,7 +177,9 @@ fn element_array_type(item: &ColumnTypeSpec) -> Option<ArrayType> {
         ColumnTypeSpec::BigInteger | ColumnTypeSpec::Timedelta => Some(ArrayType::BigInt),
         ColumnTypeSpec::Double => Some(ArrayType::Double),
         ColumnTypeSpec::Boolean => Some(ArrayType::Bool),
-        ColumnTypeSpec::Text | ColumnTypeSpec::String { .. } => Some(ArrayType::String),
+        ColumnTypeSpec::Text | ColumnTypeSpec::String { .. } | ColumnTypeSpec::Enum { .. } => {
+            Some(ArrayType::String)
+        }
         ColumnTypeSpec::Blob => Some(ArrayType::Bytes),
         ColumnTypeSpec::DateTime => Some(ArrayType::ChronoDateTime),
         ColumnTypeSpec::DateTimeUtc => Some(ArrayType::ChronoDateTimeUtc),
@@ -174,6 +190,24 @@ fn element_array_type(item: &ColumnTypeSpec) -> Option<ArrayType> {
         ColumnTypeSpec::Json | ColumnTypeSpec::JsonBinary => Some(ArrayType::Json),
         ColumnTypeSpec::Array { .. } | ColumnTypeSpec::Unknown => None,
     }
+}
+
+fn postgres_enum_cast_type(spec: &ColumnTypeSpec) -> Option<String> {
+    match spec {
+        ColumnTypeSpec::Enum { name, .. } => Some(quote_pg_type_path(name)),
+        ColumnTypeSpec::Array { item } => match item.as_ref() {
+            ColumnTypeSpec::Enum { name, .. } => Some(format!("{}[]", quote_pg_type_path(name))),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn quote_pg_type_path(name: &str) -> String {
+    name.split('.')
+        .map(|part| format!("\"{}\"", part.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(".")
 }
 
 fn string_value(s: &str) -> Value {

--- a/crates/oxyde-query/src/utils/mod.rs
+++ b/crates/oxyde-query/src/utils/mod.rs
@@ -5,6 +5,6 @@ pub mod identifier;
 pub mod value;
 
 // Re-exports for convenience
-pub use bind::{bind_value, rmpv_to_value};
+pub use bind::{bind_value, rmpv_to_value, typed_value_expr};
 pub use identifier::{ColumnIdent, TableIdent};
 pub use value::{parse_expression, rmpv_to_simple_expr};

--- a/python/oxyde/cli/migrations.py
+++ b/python/oxyde/cli/migrations.py
@@ -108,8 +108,22 @@ def makemigrations(
                 typer.echo(f"      - Add column: {op['table']}.{op['field']['name']}")
             elif op_type == "drop_column":
                 typer.echo(f"      - Drop column: {op['table']}.{op['field']}")
+            elif op_type == "alter_enum_type":
+                typer.secho(
+                    f"      - Manual enum change: {op['name']} "
+                    f"{op['old_values']} -> {op['new_values']}",
+                    fg=typer.colors.YELLOW,
+                )
             else:
                 typer.echo(f"      - {op_type}")
+
+        if any(op.get("type") == "alter_enum_type" for op in operations):
+            typer.secho(
+                "   ⚠️  One or more enum types changed in a way that requires "
+                "manual SQL. The migration file will include a ctx.require_manual(...) "
+                "guard; replace it with ctx.execute(...) and keep ctx.alter_enum_type(...).",
+                fg=typer.colors.YELLOW,
+            )
 
     except Exception as e:
         typer.secho(f"   ❌ Error computing diff: {e}", fg=typer.colors.RED)

--- a/python/oxyde/core/column_types.py
+++ b/python/oxyde/core/column_types.py
@@ -277,7 +277,9 @@ def _enum_values(enum_type: type[Enum]) -> list[str]:
         value = member.value
         if not isinstance(value, str):
             raise TypeError(
-                f"Enum field '{enum_type.__name__}' must define string values"
+                f"Enum field '{enum_type.__name__}' must define string values. "
+                "Use a str-valued Enum for database enum columns, or annotate "
+                "the field as int for integer storage."
             )
         values.append(value)
     return values

--- a/python/oxyde/core/column_types.py
+++ b/python/oxyde/core/column_types.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from enum import Enum
 from typing import Any, get_args, get_origin
 from uuid import UUID
 
@@ -107,6 +108,9 @@ def compute_column_type(
     otherwise the Python annotation. Returns None when nothing is known —
     the column is then omitted from ``column_types``.
     """
+    enum_spec = _spec_from_enum_annotation(python_type, db_type)
+    if enum_spec is not None:
+        return enum_spec
     if db_type:
         return _spec_from_db_type(db_type)
     return _spec_from_annotation(
@@ -124,6 +128,8 @@ def spec_for_literal(value_type: type) -> ColumnSpec | None:
     that msgpack-encode as strings. Returns None for types msgpack carries
     natively with correct binding.
     """
+    if _is_enum_type(value_type):
+        return _enum_spec(value_type)
     kind = _PY_SCALAR_KINDS.get(value_type)
     return {"kind": kind} if kind is not None else None
 
@@ -194,6 +200,8 @@ def _spec_from_annotation(
 
     kind = _PY_SCALAR_KINDS.get(python_type)
     if kind is None:
+        if _is_enum_type(python_type):
+            return _enum_spec(python_type)
         return None
 
     spec: ColumnSpec = {"kind": kind}
@@ -205,6 +213,72 @@ def _spec_from_annotation(
         if decimal_places is not None:
             spec["scale"] = decimal_places
     return spec
+
+
+def _spec_from_enum_annotation(
+    python_type: Any,
+    db_type: str | None,
+) -> ColumnSpec | None:
+    enum_type = _unwrap_enum_annotation(python_type)
+    if enum_type is None:
+        return None
+    if db_type:
+        db_spec = _spec_from_db_type(db_type)
+        if db_spec is not None:
+            return db_spec
+    return _enum_spec(enum_type, db_type)
+
+
+def _unwrap_enum_annotation(python_type: Any) -> type[Enum] | None:
+    origin = get_origin(python_type)
+    if origin is list:
+        return None
+    if origin is not None:
+        for arg in get_args(python_type):
+            if arg is type(None):
+                continue
+            enum_type = _unwrap_enum_annotation(arg)
+            if enum_type is not None:
+                return enum_type
+        return None
+    return python_type if _is_enum_type(python_type) else None
+
+
+def _is_enum_type(value: Any) -> bool:
+    return isinstance(value, type) and issubclass(value, Enum)
+
+
+def _enum_spec(enum_type: type[Enum], db_type: str | None = None) -> ColumnSpec:
+    return {
+        "kind": "enum",
+        "name": db_type or _default_enum_type_name(enum_type),
+        "values": _enum_values(enum_type),
+    }
+
+
+def _enum_values(enum_type: type[Enum]) -> list[str]:
+    values = []
+    for member in enum_type:
+        value = member.value
+        if not isinstance(value, str):
+            raise TypeError(
+                f"Enum field '{enum_type.__name__}' must define string values"
+            )
+        values.append(value)
+    return values
+
+
+def _default_enum_type_name(enum_type: type[Enum]) -> str:
+    name = enum_type.__name__
+    parts: list[str] = []
+    for index, char in enumerate(name):
+        if char.isupper() and index > 0:
+            prev = name[index - 1]
+            next_char = name[index + 1] if index + 1 < len(name) else ""
+            if prev != "_" and (not prev.isupper() or next_char.islower()):
+                parts.append("_")
+        parts.append(char.lower())
+    return f"{''.join(parts)}_enum"
 
 
 def _split_type_params(upper: str) -> tuple[str, list[int]]:

--- a/python/oxyde/core/column_types.py
+++ b/python/oxyde/core/column_types.py
@@ -219,29 +219,44 @@ def _spec_from_enum_annotation(
     python_type: Any,
     db_type: str | None,
 ) -> ColumnSpec | None:
-    enum_type = _unwrap_enum_annotation(python_type)
-    if enum_type is None:
+    enum_info = _enum_annotation_info(python_type)
+    if enum_info is None:
         return None
+    enum_type, is_array = enum_info
     if db_type:
         db_spec = _spec_from_db_type(db_type)
         if db_spec is not None:
             return db_spec
-    return _enum_spec(enum_type, db_type)
+    spec = _enum_spec(enum_type, _enum_type_name_from_db_type(db_type, is_array))
+    return {"kind": "array", "item": spec} if is_array else spec
 
 
-def _unwrap_enum_annotation(python_type: Any) -> type[Enum] | None:
+def _enum_annotation_info(python_type: Any) -> tuple[type[Enum], bool] | None:
     origin = get_origin(python_type)
     if origin is list:
-        return None
+        args = get_args(python_type)
+        if not args:
+            return None
+        inner = _enum_annotation_info(args[0])
+        return (inner[0], True) if inner is not None else None
     if origin is not None:
         for arg in get_args(python_type):
             if arg is type(None):
                 continue
-            enum_type = _unwrap_enum_annotation(arg)
-            if enum_type is not None:
-                return enum_type
+            enum_info = _enum_annotation_info(arg)
+            if enum_info is not None:
+                return enum_info
         return None
-    return python_type if _is_enum_type(python_type) else None
+    return (python_type, False) if _is_enum_type(python_type) else None
+
+
+def _enum_type_name_from_db_type(db_type: str | None, is_array: bool) -> str | None:
+    if db_type is None:
+        return None
+    name = db_type.strip()
+    if is_array and name.upper().endswith("[]"):
+        name = name[:-2].strip()
+    return name
 
 
 def _is_enum_type(value: Any) -> bool:

--- a/python/oxyde/core/types.py
+++ b/python/oxyde/core/types.py
@@ -15,6 +15,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from enum import Enum
 from typing import Any
 from uuid import UUID
 
@@ -55,6 +56,8 @@ def serialize_value(value: Any) -> Any:
         return [serialize_value(v) for v in value]
     if isinstance(value, dict):
         return {k: serialize_value(v) for k, v in value.items()}
+    if isinstance(value, Enum):
+        return value.value
     desc = TYPE_REGISTRY.get(type(value))
     if desc is not None:
         return desc.serialize(value)

--- a/python/oxyde/migrations/context.py
+++ b/python/oxyde/migrations/context.py
@@ -21,6 +21,11 @@ if TYPE_CHECKING:
     from oxyde.migrations.replay import SchemaState
 
 
+def _is_postgres_enum_add_value_sql(sql: str) -> bool:
+    upper = sql.strip().upper()
+    return upper.startswith("ALTER TYPE ") and " ADD VALUE " in upper
+
+
 class MigrationContext:
     """Context for executing migrations.
 
@@ -62,6 +67,67 @@ class MigrationContext:
             Database dialect: "sqlite", "postgres", or "mysql"
         """
         return self._dialect
+
+    def create_enum_type(self, name: str, values: list[str]) -> None:
+        op = {
+            "type": "create_enum_type",
+            "name": name,
+            "values": values,
+        }
+
+        if self._mode == "collect":
+            self._operations.append(op)
+        else:
+            self._execute_operation(op)
+
+    def drop_enum_type(self, name: str) -> None:
+        op = {
+            "type": "drop_enum_type",
+            "name": name,
+        }
+
+        if self._mode == "collect":
+            self._operations.append(op)
+        else:
+            self._execute_operation(op)
+
+    def add_enum_value(
+        self,
+        name: str,
+        value: str,
+        fields: list[dict[str, Any]] | None = None,
+    ) -> None:
+        op = {
+            "type": "add_enum_value",
+            "name": name,
+            "value": value,
+            "fields": fields or [],
+        }
+
+        if self._mode == "collect":
+            self._operations.append(op)
+        else:
+            self._execute_operation(op)
+
+    def alter_enum_type(
+        self,
+        name: str,
+        old_values: list[str],
+        new_values: list[str],
+    ) -> None:
+        op = {
+            "type": "alter_enum_type",
+            "name": name,
+            "old_values": old_values,
+            "new_values": new_values,
+        }
+
+        if self._mode == "collect":
+            self._operations.append(op)
+
+    def require_manual(self, message: str) -> None:
+        if self._mode == "execute":
+            raise RuntimeError(message)
 
     # ========================================================================
     # Table operations
@@ -482,7 +548,7 @@ class MigrationContext:
         This is called by the executor after upgrade() completes.
 
         Transaction behavior by dialect:
-        - PostgreSQL: DDL is transactional, uses Rust transaction API
+        - PostgreSQL: DDL is transactional except ALTER TYPE ADD VALUE chains
         - SQLite: DDL is transactional, uses Rust transaction API
         - MySQL: DDL is NOT transactional (implicit commit), no wrapping
 
@@ -497,8 +563,7 @@ class MigrationContext:
         if self._db_conn is None:
             raise RuntimeError("Cannot execute SQL: no database connection provided")
 
-        # MySQL doesn't support transactional DDL
-        use_transaction = self._dialect in ("postgres", "sqlite")
+        use_transaction = self._should_use_transaction()
 
         tx_id = None
         try:
@@ -527,6 +592,16 @@ class MigrationContext:
         finally:
             # Clear collected statements
             self._sql_statements = []
+
+    def _should_use_transaction(self) -> bool:
+        if self._dialect == "mysql":
+            return False
+        if self._dialect == "postgres" and any(
+            _is_postgres_enum_add_value_sql(sql)
+            for sql in getattr(self, "_sql_statements", [])
+        ):
+            return False
+        return self._dialect in ("postgres", "sqlite")
 
 
 __all__ = ["MigrationContext"]

--- a/python/oxyde/migrations/extract.py
+++ b/python/oxyde/migrations/extract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, time
 from decimal import Decimal
+from enum import Enum
 from typing import Any
 from uuid import UUID
 
@@ -78,6 +79,10 @@ def _serialize_default(value: Any, dialect: str) -> str | None:
     # User should use db_default for SQL expressions
     if callable(value):
         return None
+
+    if isinstance(value, Enum):
+        escaped = str(value.value).replace("'", "''")
+        return f"'{escaped}'"
 
     # String - quote it
     if isinstance(value, str):

--- a/python/oxyde/migrations/generator.py
+++ b/python/oxyde/migrations/generator.py
@@ -66,7 +66,41 @@ def _operation_to_python(op: dict[str, Any], indent: str = "    ") -> str:
     """
     op_type = op.get("type")
 
-    if op_type == "create_table":
+    if op_type == "create_enum_type":
+        values_repr = _python_repr(op["values"])
+        return f"{indent}ctx.create_enum_type({_python_repr(op['name'])}, {values_repr})"
+
+    elif op_type == "drop_enum_type":
+        return f"{indent}ctx.drop_enum_type({_python_repr(op['name'])})"
+
+    elif op_type == "add_enum_value":
+        args = f"{_python_repr(op['name'])}, {_python_repr(op['value'])}"
+        if fields := op.get("fields"):
+            return (
+                f"{indent}ctx.add_enum_value(\n"
+                f"{indent}    {args},\n"
+                f"{indent}    fields={_python_repr(fields, indent=len(indent) + 11)},\n"
+                f"{indent})"
+            )
+        return f"{indent}ctx.add_enum_value({args})"
+
+    elif op_type == "alter_enum_type":
+        message = (
+            f"Manual enum migration required for {op['name']}: "
+            f"{op['old_values']!r} -> {op['new_values']!r}. "
+            "Replace ctx.require_manual(...) with ctx.execute(...) statements and keep "
+            "ctx.alter_enum_type(...) to update migration replay state."
+        )
+        return (
+            f"{indent}ctx.alter_enum_type(\n"
+            f"{indent}    {_python_repr(op['name'])},\n"
+            f"{indent}    old_values={_python_repr(op['old_values'], indent=len(indent) + 15)},\n"
+            f"{indent}    new_values={_python_repr(op['new_values'], indent=len(indent) + 15)},\n"
+            f"{indent})\n"
+            f"{indent}ctx.require_manual({_python_repr(message)})"
+        )
+
+    elif op_type == "create_table":
         table = op["table"]
         tname = table["name"]
         # Use consistent indentation for all kwargs
@@ -201,7 +235,15 @@ def _infer_migration_name(operations: list[dict[str, Any]]) -> str:
     first_op = operations[0]
     op_type = first_op.get("type")
 
-    if op_type == "create_table":
+    if op_type == "create_enum_type":
+        return f"create_{first_op['name']}_enum"
+    elif op_type == "drop_enum_type":
+        return f"drop_{first_op['name']}_enum"
+    elif op_type == "add_enum_value":
+        return f"add_{first_op['value']}_to_{first_op['name']}_enum"
+    elif op_type == "alter_enum_type":
+        return f"alter_{first_op['name']}_enum"
+    elif op_type == "create_table":
         table_name = first_op["table"]["name"]
         return f"create_{table_name}_table"
     elif op_type == "drop_table":
@@ -306,7 +348,46 @@ def generate_migration_file(
         op_type = op.get("type")
 
         # Generate reverse operation
-        if op_type == "create_table":
+        if op_type == "create_enum_type":
+            downgrade_lines.append(
+                f"    ctx.drop_enum_type({_python_repr(op['name'])})"
+            )
+        elif op_type == "drop_enum_type":
+            values = op.get("values")
+            if values:
+                values_repr = _python_repr(values)
+                downgrade_lines.append(
+                    f"    ctx.create_enum_type({_python_repr(op['name'])}, {values_repr})"
+                )
+            else:
+                message = f"Cannot recreate enum type {op['name']} without its values"
+                downgrade_lines.append(
+                    f"    raise RuntimeError({_python_repr(message)})"
+                )
+        elif op_type == "add_enum_value":
+            message = (
+                f"Cannot automatically remove enum value {op['value']} "
+                f"from {op['name']}"
+            )
+            downgrade_lines.append(
+                f"    raise RuntimeError({_python_repr(message)})"
+            )
+        elif op_type == "alter_enum_type":
+            message = (
+                f"Manual enum migration required for {op['name']}: "
+                f"{op['new_values']!r} -> {op['old_values']!r}. "
+                "Replace ctx.require_manual(...) with ctx.execute(...) statements and keep "
+                "ctx.alter_enum_type(...) to update migration replay state."
+            )
+            downgrade_lines.append(
+                f"    ctx.alter_enum_type(\n"
+                f"        {_python_repr(op['name'])},\n"
+                f"        old_values={_python_repr(op['new_values'], indent=19)},\n"
+                f"        new_values={_python_repr(op['old_values'], indent=19)},\n"
+                f"    )\n"
+                f"    ctx.require_manual({_python_repr(message)})"
+            )
+        elif op_type == "create_table":
             downgrade_lines.append(f'    ctx.drop_table("{op["table"]["name"]}")')
         elif op_type == "drop_table":
             # Reverse drop_table by recreating the table from stored structure

--- a/python/oxyde/migrations/replay.py
+++ b/python/oxyde/migrations/replay.py
@@ -14,6 +14,37 @@ from oxyde.migrations.utils import (
 )
 
 
+def _add_enum_value_to_spec(spec: dict[str, Any], name: str, value: str) -> dict[str, Any]:
+    if spec.get("kind") == "enum" and spec.get("name") == name:
+        updated = dict(spec)
+        values = list(updated.get("values", []))
+        if value not in values:
+            values.append(value)
+        updated["values"] = values
+        return updated
+    if spec.get("kind") == "array" and isinstance(spec.get("item"), dict):
+        updated = dict(spec)
+        updated["item"] = _add_enum_value_to_spec(spec["item"], name, value)
+        return updated
+    return spec
+
+
+def _replace_enum_values_in_spec(
+    spec: dict[str, Any],
+    name: str,
+    values: list[str],
+) -> dict[str, Any]:
+    if spec.get("kind") == "enum" and spec.get("name") == name:
+        updated = dict(spec)
+        updated["values"] = list(values)
+        return updated
+    if spec.get("kind") == "array" and isinstance(spec.get("item"), dict):
+        updated = dict(spec)
+        updated["item"] = _replace_enum_values_in_spec(spec["item"], name, values)
+        return updated
+    return spec
+
+
 class SchemaState:
     """Represents database schema in memory.
 
@@ -32,7 +63,37 @@ class SchemaState:
         """
         op_type = op.get("type")
 
-        if op_type == "create_table":
+        if op_type == "create_enum_type":
+            pass
+
+        elif op_type == "drop_enum_type":
+            pass
+
+        elif op_type == "add_enum_value":
+            enum_name = op["name"]
+            enum_value = op["value"]
+            for table in self.tables.values():
+                for field in table["fields"]:
+                    if column_type := field.get("column_type"):
+                        field["column_type"] = _add_enum_value_to_spec(
+                            column_type,
+                            enum_name,
+                            enum_value,
+                        )
+
+        elif op_type == "alter_enum_type":
+            enum_name = op["name"]
+            enum_values = op["new_values"]
+            for table in self.tables.values():
+                for field in table["fields"]:
+                    if column_type := field.get("column_type"):
+                        field["column_type"] = _replace_enum_values_in_spec(
+                            column_type,
+                            enum_name,
+                            enum_values,
+                        )
+
+        elif op_type == "create_table":
             table = op["table"]
             self.tables[table["name"]] = {
                 "name": table["name"],

--- a/python/oxyde/queries/mixins/mutation.py
+++ b/python/oxyde/queries/mixins/mutation.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Literal, overload
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Literal, get_args, get_origin, overload
+
+from pydantic import TypeAdapter
 
 from oxyde._msgpack import msgpack
 from oxyde.core import ir
@@ -14,6 +17,7 @@ from oxyde.models.serializers import (
     _dump_insert_data,
     _normalize_instance,
 )
+from oxyde.models.utils import _unpack_annotated, _unwrap_optional
 from oxyde.queries.base import (
     SupportsExecute,
     _build_column_types,
@@ -22,7 +26,7 @@ from oxyde.queries.base import (
     _model_key,
     _resolve_execution_client,
 )
-from oxyde.queries.expressions import F, _serialize_value_for_ir
+from oxyde.queries.expressions import F, _Expression, _serialize_value_for_ir
 from oxyde.queries.insert import InsertQuery
 
 if TYPE_CHECKING:
@@ -64,6 +68,39 @@ def _decode_columnar_models(model_class: type[Model], result: list[Any]) -> list
     if len(result) < 2 or not result[1]:
         return []
     return _hydrate_models(model_class, result[0], result[1])
+
+
+def _is_enum_annotation(annotation: Any) -> bool:
+    annotation, _ = _unpack_annotated(annotation)
+    annotation, _ = _unwrap_optional(annotation)
+    origin = get_origin(annotation)
+    if origin is list:
+        args = get_args(annotation)
+        return bool(args) and _is_enum_annotation(args[0])
+    if origin is not None:
+        return any(
+            arg is not type(None) and _is_enum_annotation(arg)
+            for arg in get_args(annotation)
+        )
+    return isinstance(annotation, type) and issubclass(annotation, Enum)
+
+
+def _validate_enum_update_values(
+    model_class: type[Model],
+    values: dict[str, Any],
+) -> dict[str, Any]:
+    validated = dict(values)
+    metadata = model_class._db_meta.field_metadata
+    for field, value in values.items():
+        if isinstance(value, (F, _Expression)):
+            continue
+        meta = metadata.get(field)
+        if meta is not None and _is_enum_annotation(meta.python_type):
+            if value is None and meta.nullable:
+                validated[field] = None
+            else:
+                validated[field] = TypeAdapter(meta.python_type).validate_python(value)
+    return validated
 
 
 class MutationMixin:
@@ -164,6 +201,7 @@ class MutationMixin:
         """
         exec_client = await _resolve_execution_client(using, client)
         column_types = _build_column_types(self.model_class)
+        values = _validate_enum_update_values(self.model_class, values)
         mapped_values = _map_values_to_columns(self.model_class, values)
         serialized_values = {
             key: _serialize_value_for_ir(value) for key, value in mapped_values.items()

--- a/python/oxyde/queries/select.py
+++ b/python/oxyde/queries/select.py
@@ -211,6 +211,22 @@ class Query(
         clone._lock_type = "share"
         return clone
 
+    def _column_types_for_query(self) -> dict[str, dict] | None:
+        """Return base and joined column type specs keyed by SQL/result column names."""
+        base_types = self.model_class._db_meta.column_types or {}
+        column_types: dict[str, dict] = dict(base_types)
+
+        for descriptor in self._join_specs:
+            target_types = descriptor.target_model._db_meta.column_types or {}
+            for _, column in descriptor.columns:
+                spec = target_types.get(column)
+                if spec is None:
+                    continue
+                column_types[f"{descriptor.alias}.{column}"] = spec
+                column_types[f"{descriptor.result_prefix}__{column}"] = spec
+
+        return column_types or None
+
     def to_ir(self) -> dict[str, Any]:
         """Convert query to IR format for Rust execution."""
         from oxyde.models.base import Model
@@ -273,8 +289,8 @@ class Query(
                 self._column_for_field(field) for field in self._group_by_fields
             ]
 
-        # Use cached col_types from model metadata (computed at finalization)
-        column_types = self.model_class._db_meta.column_types
+        # Use cached col_types from model metadata plus joined column aliases.
+        column_types = self._column_types_for_query()
 
         # Pass pk_column only for JOIN queries (needed for deduplication)
         pk_column = None

--- a/python/oxyde/tests/integration/test_enum_roundtrip.py
+++ b/python/oxyde/tests/integration/test_enum_roundtrip.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from enum import Enum
+
+import pytest
+import pytest_asyncio
+
+from oxyde import AsyncDatabase, Field, Model, disconnect_all
+from oxyde.db.schema import create_tables
+from oxyde.models.registry import clear_registry, register_table
+from oxyde.queries.raw import execute_raw
+
+from .conftest import _get_url
+
+
+class LiveStatus(str, Enum):
+    DRAFT = "draft"
+    PUBLISHED = "published"
+    ARCHIVED = "archived"
+
+
+class EnumRoundTrip(Model):
+    id: int | None = Field(default=None, db_pk=True)
+    status: LiveStatus = Field(default=LiveStatus.DRAFT)
+    labels: list[LiveStatus] | None = Field(default=None, db_nullable=True)
+
+    class Meta:
+        is_table = True
+        table_name = "enum_roundtrip_test"
+
+
+@pytest_asyncio.fixture(params=["postgres", "mysql"])
+async def enum_db(request, tmp_path, _pg_container, _mysql_container):
+    dialect = request.param
+    url = _get_url(dialect, tmp_path, _pg_container, _mysql_container)
+
+    clear_registry()
+    register_table(EnumRoundTrip, overwrite=True)
+
+    database = AsyncDatabase(
+        url, name=f"enum_roundtrip_{dialect}", overwrite=True
+    )
+    await database.connect()
+
+    try:
+        await _drop_enum_roundtrip_schema(database, dialect)
+        await create_tables(database)
+        yield database
+    finally:
+        await _drop_enum_roundtrip_schema(database, dialect)
+        await disconnect_all()
+        clear_registry()
+
+
+async def _drop_enum_roundtrip_schema(database: AsyncDatabase, dialect: str) -> None:
+    if dialect == "postgres":
+        await execute_raw(
+            "DROP TABLE IF EXISTS enum_roundtrip_test CASCADE", client=database
+        )
+        await execute_raw("DROP TYPE IF EXISTS live_status_enum CASCADE", client=database)
+    else:
+        await execute_raw("DROP TABLE IF EXISTS enum_roundtrip_test", client=database)
+
+
+class TestEnumRoundTrip:
+    @pytest.mark.asyncio
+    async def test_create_filter_update_fetch_scalar_and_array(self, enum_db):
+        created = await EnumRoundTrip.objects.create(
+            status=LiveStatus.DRAFT,
+            labels=[LiveStatus.DRAFT, LiveStatus.PUBLISHED],
+            using=enum_db.name,
+        )
+
+        fetched = await EnumRoundTrip.objects.get(id=created.id, using=enum_db.name)
+        assert fetched.status is LiveStatus.DRAFT
+        assert fetched.labels == [LiveStatus.DRAFT, LiveStatus.PUBLISHED]
+
+        matched = await EnumRoundTrip.objects.filter(
+            status=LiveStatus.DRAFT
+        ).get(using=enum_db.name)
+        assert matched.id == created.id
+
+        affected = await EnumRoundTrip.objects.filter(id=created.id).update(
+            status="published",
+            labels=["published", LiveStatus.ARCHIVED],
+            using=enum_db.name,
+        )
+        assert affected == 1
+
+        updated = await EnumRoundTrip.objects.get(id=created.id, using=enum_db.name)
+        assert updated.status is LiveStatus.PUBLISHED
+        assert updated.labels == [LiveStatus.PUBLISHED, LiveStatus.ARCHIVED]

--- a/python/oxyde/tests/unit/test_db_types.py
+++ b/python/oxyde/tests/unit/test_db_types.py
@@ -8,12 +8,18 @@ from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from enum import Enum
 from typing import Annotated
 from uuid import UUID
 
 import pytest
 
 from oxyde import Field, Model
+
+
+class Status(Enum):
+    DRAFT = "draft"
+    PUBLISHED = "published"
 
 
 # ── Model with all type variations ────────────────────────────────────
@@ -35,6 +41,7 @@ class DbTypesModel(Model):
     infer_uuid: UUID | None = Field(default=None, db_nullable=True)
     infer_decimal: Decimal | None = Field(default=None, db_nullable=True)
     infer_json: dict | None = Field(default=None, db_nullable=True)
+    infer_enum: Status = Field(default=Status.DRAFT)
 
     # Explicit db_type (scalar)
     db_uuid: str = Field(default="", db_type="UUID")
@@ -67,12 +74,15 @@ class DbTypesModel(Model):
     db_real: float = Field(default=0.0, db_type="REAL")
     db_bytea: bytes | None = Field(default=None, db_nullable=True, db_type="BYTEA")
     db_blob: bytes | None = Field(default=None, db_nullable=True, db_type="BLOB")
+    db_enum: Status = Field(default=Status.DRAFT, db_type="post_status_enum")
+    db_enum_as_text: Status = Field(default=Status.DRAFT, db_type="TEXT")
 
     # Inferred array types (no db_type)
     infer_str_list: list[str] | None = Field(default=None, db_nullable=True)
     infer_int_list: list[int] | None = Field(default=None, db_nullable=True)
     infer_uuid_list: list[UUID] | None = Field(default=None, db_nullable=True)
     infer_decimal_list: list[Decimal] | None = Field(default=None, db_nullable=True)
+    infer_enum_list: list[Status] | None = Field(default=None, db_nullable=True)
 
     # Explicit db_type on arrays
     db_varchar_arr: list[str] | None = Field(
@@ -120,6 +130,10 @@ COL_TYPE_CASES = [
     ("infer_uuid", {"kind": "uuid"}),
     ("infer_decimal", {"kind": "decimal"}),
     ("infer_json", {"kind": "json"}),
+    (
+        "infer_enum",
+        {"kind": "enum", "name": "status_enum", "values": ["draft", "published"]},
+    ),
     # Explicit db_type scalar — semantic kind via KNOWN_DB_TYPES,
     # the verbatim string travels separately (FieldDef.db_type)
     ("db_uuid", {"kind": "uuid"}),
@@ -144,11 +158,31 @@ COL_TYPE_CASES = [
     ("db_real", {"kind": "double"}),
     ("db_bytea", {"kind": "blob"}),
     ("db_blob", {"kind": "blob"}),
+    (
+        "db_enum",
+        {
+            "kind": "enum",
+            "name": "post_status_enum",
+            "values": ["draft", "published"],
+        },
+    ),
+    ("db_enum_as_text", {"kind": "text"}),
     # Inferred arrays
     ("infer_str_list", {"kind": "array", "item": {"kind": "string"}}),
     ("infer_int_list", {"kind": "array", "item": {"kind": "big_integer"}}),
     ("infer_uuid_list", {"kind": "array", "item": {"kind": "uuid"}}),
     ("infer_decimal_list", {"kind": "array", "item": {"kind": "decimal"}}),
+    (
+        "infer_enum_list",
+        {
+            "kind": "array",
+            "item": {
+                "kind": "enum",
+                "name": "status_enum",
+                "values": ["draft", "published"],
+            },
+        },
+    ),
     # Explicit db_type arrays — kind per element, params parsed
     ("db_varchar_arr", {"kind": "array", "item": {"kind": "string", "length": 100}}),
     (

--- a/python/oxyde/tests/unit/test_db_types.py
+++ b/python/oxyde/tests/unit/test_db_types.py
@@ -100,6 +100,9 @@ class DbTypesModel(Model):
     db_text_arr: list[str] | None = Field(
         default=None, db_nullable=True, db_type="TEXT[]"
     )
+    db_enum_arr: list[Status] | None = Field(
+        default=None, db_nullable=True, db_type="post_status_enum[]"
+    )
 
     # Annotated inner constraints on arrays
     ann_str_list: list[Annotated[str, Field(max_length=100)]] | None = Field(
@@ -192,6 +195,17 @@ COL_TYPE_CASES = [
     ("db_uuid_arr", {"kind": "array", "item": {"kind": "uuid"}}),
     ("db_int_arr", {"kind": "array", "item": {"kind": "big_integer"}}),
     ("db_text_arr", {"kind": "array", "item": {"kind": "text"}}),
+    (
+        "db_enum_arr",
+        {
+            "kind": "array",
+            "item": {
+                "kind": "enum",
+                "name": "post_status_enum",
+                "values": ["draft", "published"],
+            },
+        },
+    ),
     # Annotated inner arrays (inferred from python_type)
     ("ann_str_list", {"kind": "array", "item": {"kind": "string", "length": 100}}),
     ("ann_decimal_list", {"kind": "array", "item": {"kind": "decimal", "precision": 10, "scale": 2}}),

--- a/python/oxyde/tests/unit/test_db_types.py
+++ b/python/oxyde/tests/unit/test_db_types.py
@@ -8,18 +8,24 @@ from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Annotated
 from uuid import UUID
 
 import pytest
 
 from oxyde import Field, Model
+from oxyde.models.registry import clear_registry
 
 
 class Status(Enum):
     DRAFT = "draft"
     PUBLISHED = "published"
+
+
+class Priority(IntEnum):
+    LOW = 1
+    HIGH = 2
 
 
 # ── Model with all type variations ────────────────────────────────────
@@ -219,6 +225,19 @@ class TestColTypes:
         assert column_types[field] == expected, (
             f"{field}: got {column_types.get(field)!r}, expected {expected!r}"
         )
+
+    def test_int_enum_error_is_actionable(self):
+        clear_registry()
+
+        with pytest.raises(TypeError, match="Use a str-valued Enum"):
+
+            class Task(Model):
+                id: int | None = Field(default=None, db_pk=True)
+                priority: Priority = Field(default=Priority.LOW)
+
+                class Meta:
+                    is_table = True
+                    table_name = "int_enum_tasks"
 
 
 # ── Annotated inner constraints extraction ────────────────────────────

--- a/python/oxyde/tests/unit/test_migrations_execution.py
+++ b/python/oxyde/tests/unit/test_migrations_execution.py
@@ -13,7 +13,6 @@ from oxyde.migrations.context import MigrationContext
 from oxyde.migrations.replay import SchemaState
 
 
-
 @pytest.fixture
 def temp_migrations_dir():
     """Create a temporary migrations directory."""
@@ -355,6 +354,9 @@ class TestMigrationValidation:
         for name in invalid_names:
             assert not re.match(pattern, name), f"{name} should be invalid"
 
+        for name in invalid_names:
+            assert not re.match(pattern, name), f"{name} should be invalid"
+
     def test_validate_table_name(self):
         """Test table name validation."""
         import re
@@ -381,6 +383,9 @@ class TestMigrationValidation:
 
         for name in valid_names:
             assert re.match(pattern, name), f"{name} should be valid"
+
+        for name in invalid_names:
+            assert not re.match(pattern, name), f"{name} should be invalid"
 
 
 class TestMigrationDependencies:
@@ -562,6 +567,23 @@ class TestDropOpsMinimalPayloadRegression:
         # Must not raise — round-trip through Rust must succeed
         sqls = migration_to_sql(ops_json, "postgres")
         assert any("idx_users_email" in s for s in sqls)
+
+
+class TestMigrationTransactionMode:
+    def test_postgres_enum_add_value_runs_without_transaction(self):
+        ctx = MigrationContext(mode="execute", dialect="postgres")
+        ctx._sql_statements = [
+            'ALTER TYPE "post_status_enum" ADD VALUE IF NOT EXISTS \'archived\'',
+            'CREATE INDEX "posts_archived_idx" ON "posts" ("status")',
+        ]
+
+        assert ctx._should_use_transaction() is False
+
+    def test_regular_postgres_migration_uses_transaction(self):
+        ctx = MigrationContext(mode="execute", dialect="postgres")
+        ctx._sql_statements = ['CREATE TABLE "users" ("id" BIGINT)']
+
+        assert ctx._should_use_transaction() is True
 
 
 ALL_DIALECTS = ["postgres", "mysql", "sqlite"]

--- a/python/oxyde/tests/unit/test_migrations_pipeline.py
+++ b/python/oxyde/tests/unit/test_migrations_pipeline.py
@@ -15,6 +15,7 @@ where Python/Rust payload shapes diverged silently.
 from __future__ import annotations
 
 import json
+from enum import Enum
 from pathlib import Path
 
 import pytest
@@ -24,13 +25,18 @@ from oxyde.core import migration_compute_diff, migration_to_sql
 from oxyde.migrations.context import MigrationContext
 from oxyde.migrations.extract import extract_current_schema
 from oxyde.migrations.generator import generate_migration_file
+from oxyde.migrations.replay import replay_migrations
 from oxyde.migrations.utils import load_migration_module
 from oxyde.models.registry import clear_registry
-
 
 ALL_DIALECTS = ["postgres", "mysql", "sqlite"]
 NON_SQLITE = ["postgres", "mysql"]
 PARTIAL_INDEX_DIALECTS = ["postgres", "sqlite"]
+
+
+class PublishState(Enum):
+    DRAFT = "draft"
+    PUBLISHED = "published"
 
 
 def _snapshot_from_models(models: list[type[Model]], dialect: str) -> dict:
@@ -79,6 +85,47 @@ def _run_pipeline(
     return ops, up_sql, down_sql
 
 
+def _enum_snapshot(values: list[str]) -> dict:
+    return {
+        "version": 1,
+        "tables": {
+            "articles": {
+                "name": "articles",
+                "fields": [
+                    {
+                        "name": "id",
+                        "column_type": {"kind": "big_integer"},
+                        "db_type": None,
+                        "nullable": False,
+                        "primary_key": True,
+                        "unique": False,
+                        "default": None,
+                        "auto_increment": False,
+                    },
+                    {
+                        "name": "state",
+                        "column_type": {
+                            "kind": "enum",
+                            "name": "publish_state_enum",
+                            "values": values,
+                        },
+                        "db_type": None,
+                        "nullable": False,
+                        "primary_key": False,
+                        "unique": False,
+                        "default": None,
+                        "auto_increment": False,
+                    },
+                ],
+                "indexes": [],
+                "foreign_keys": [],
+                "checks": [],
+                "comment": None,
+            }
+        },
+    }
+
+
 class TestCreateTablePipeline:
     @pytest.mark.parametrize("dialect", ALL_DIALECTS)
     def test_create_table_from_scratch(self, tmp_path, dialect):
@@ -98,6 +145,117 @@ class TestCreateTablePipeline:
         assert any(op["type"] == "create_table" for op in ops)
         assert any("CREATE TABLE" in s.upper() and "users" in s for s in up_sql)
         assert any("DROP TABLE" in s.upper() and "users" in s for s in down_sql)
+
+
+class TestEnumPipeline:
+    @pytest.mark.parametrize("dialect", ALL_DIALECTS)
+    def test_create_table_with_enum(self, tmp_path, dialect):
+        class Article(Model):
+            id: int | None = Field(default=None, db_pk=True)
+            state: PublishState = Field(default=PublishState.DRAFT)
+
+            class Meta:
+                is_table = True
+                table_name = "articles"
+
+        ops, up_sql, down_sql = _run_pipeline(
+            [], [Article], dialect, tmp_path, "create_articles"
+        )
+
+        assert [op["type"] for op in ops[:2]] == ["create_enum_type", "create_table"]
+        if dialect == "postgres":
+            assert up_sql[0] == (
+                'CREATE TYPE "publish_state_enum" AS ENUM ('
+                "'draft', 'published')"
+            )
+            assert any('"state" "publish_state_enum" NOT NULL' in s for s in up_sql)
+            assert down_sql[-1] == 'DROP TYPE "publish_state_enum"'
+        elif dialect == "mysql":
+            assert not any("CREATE TYPE" in s.upper() for s in up_sql)
+            assert any("ENUM('draft','published')" in s for s in up_sql)
+        else:
+            assert not any("CREATE TYPE" in s.upper() for s in up_sql)
+            assert any('"state" TEXT NOT NULL' in s for s in up_sql)
+
+    def test_add_enum_value_diff_emits_enum_op_only(self):
+        old = _enum_snapshot(["draft", "published"])
+        new = _enum_snapshot(["draft", "published", "archived"])
+
+        ops_json = migration_compute_diff(json.dumps(old), json.dumps(new))
+        ops = json.loads(ops_json)
+
+        assert len(ops) == 1
+        op = ops[0]
+        assert op["type"] == "add_enum_value"
+        assert op["name"] == "publish_state_enum"
+        assert op["value"] == "archived"
+        assert op["fields"][0]["table"] == "articles"
+        assert op["fields"][0]["field"]["name"] == "state"
+        assert migration_to_sql(ops_json, "postgres") == [
+            'ALTER TYPE "publish_state_enum" ADD VALUE IF NOT EXISTS \'archived\''
+        ]
+        assert migration_to_sql(ops_json, "mysql") == [
+            "ALTER TABLE `articles` MODIFY COLUMN `state` ENUM('draft','published','archived') NOT NULL"
+        ]
+
+    def test_add_multiple_enum_values_updates_mysql_inline_enum_progressively(self):
+        old = _enum_snapshot(["draft", "published"])
+        new = _enum_snapshot(["draft", "published", "archived", "deleted"])
+
+        ops_json = migration_compute_diff(json.dumps(old), json.dumps(new))
+        ops = json.loads(ops_json)
+
+        assert [op["value"] for op in ops] == ["archived", "deleted"]
+        assert migration_to_sql(ops_json, "mysql") == [
+            "ALTER TABLE `articles` MODIFY COLUMN `state` ENUM('draft','published','archived') NOT NULL",
+            "ALTER TABLE `articles` MODIFY COLUMN `state` ENUM('draft','published','archived','deleted') NOT NULL",
+        ]
+
+    def test_enum_value_removal_requires_manual_migration(self):
+        old = _enum_snapshot(["draft", "published"])
+        new = _enum_snapshot(["draft"])
+
+        ops_json = migration_compute_diff(json.dumps(old), json.dumps(new))
+        ops = json.loads(ops_json)
+
+        assert ops == [
+            {
+                "type": "alter_enum_type",
+                "name": "publish_state_enum",
+                "old_values": ["draft", "published"],
+                "new_values": ["draft"],
+            }
+        ]
+
+    def test_manual_enum_migration_file_contains_replay_marker(self, tmp_path):
+        old = _enum_snapshot(["draft", "published"])
+        new = _enum_snapshot(["draft"])
+        ops = json.loads(migration_compute_diff(json.dumps(old), json.dumps(new)))
+
+        empty = {"version": 1, "tables": {}}
+        create_ops = json.loads(migration_compute_diff(json.dumps(empty), json.dumps(old)))
+        generate_migration_file(
+            create_ops,
+            migrations_dir=tmp_path,
+            name="create_articles",
+        )
+        filepath = generate_migration_file(
+            ops,
+            migrations_dir=tmp_path,
+            name="alter_publish_state",
+        )
+        content = filepath.read_text()
+
+        assert "Manual enum migration required for publish_state_enum" in content
+        assert "ctx.alter_enum_type(" in content
+        assert "ctx.require_manual(" in content
+        assert "raise RuntimeError" not in content
+        assert "old_values=[" in content
+        assert "new_values=[" in content
+
+        replayed = replay_migrations(str(tmp_path))
+        state_field = replayed["tables"]["articles"]["fields"][1]
+        assert state_field["column_type"]["values"] == ["draft"]
 
 
 class TestAddColumnPipeline:

--- a/python/oxyde/tests/unit/test_migrations_squash.py
+++ b/python/oxyde/tests/unit/test_migrations_squash.py
@@ -118,6 +118,59 @@ class TestSquash:
         assert result.raw_sql_files == ["0002_add_age.py"]
         assert sorted(result.legacy_files) == ["0001_users.py", "0002_add_age.py"]
 
+    def test_legacy_field_next_to_enum_add_value_replays(self, tmp_path):
+        (tmp_path / "0001_create.py").write_text(
+            '''depends_on = None
+
+
+def upgrade(ctx):
+    ctx.create_enum_type("status_enum", ["draft"])
+    ctx.create_table(
+        "articles",
+        fields=[
+            {
+                "name": "id",
+                "python_type": "int",
+                "db_type": None,
+                "nullable": False,
+                "primary_key": True,
+                "unique": False,
+                "default": None,
+                "auto_increment": True,
+            },
+            {
+                "name": "status",
+                "column_type": {
+                    "kind": "enum",
+                    "name": "status_enum",
+                    "values": ["draft"],
+                },
+                "db_type": None,
+                "nullable": False,
+                "primary_key": False,
+                "unique": False,
+                "default": None,
+                "auto_increment": False,
+            },
+        ],
+    )
+'''
+        )
+        (tmp_path / "0002_add_value.py").write_text(
+            '''depends_on = "0001_create"
+
+
+def upgrade(ctx):
+    ctx.add_enum_value("status_enum", "published")
+'''
+        )
+
+        snapshot = replay_migrations(str(tmp_path))
+
+        fields = snapshot["tables"]["articles"]["fields"]
+        status = next(field for field in fields if field["name"] == "status")
+        assert status["column_type"]["values"] == ["draft", "published"]
+
     def test_squashed_history_replays_to_same_schema(self, tmp_path, recwarn):
         _write_legacy_history(tmp_path)
         before = replay_migrations(str(tmp_path))

--- a/python/oxyde/tests/unit/test_query.py
+++ b/python/oxyde/tests/unit/test_query.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from enum import Enum
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, ClassVar
 
 import msgpack
 import pytest
+from pydantic import ValidationError
 
 from oxyde import Field, Model
 from oxyde.db import atomic
@@ -161,7 +163,7 @@ def test_field_metadata_captures_db_attributes() -> None:
     # db_type is NOT auto-inferred - only set if user explicitly specifies Field(db_type="...")
     # Type inference happens at schema extraction time based on dialect
     assert user_meta.field_metadata["email"].db_type is None
-    assert user_meta.field_metadata["email"].python_type == str
+    assert user_meta.field_metadata["email"].python_type is str
 
     article_meta = Article._db_meta
 
@@ -410,6 +412,71 @@ async def test_async_manager_create_update_delete_and_save() -> None:
     )
     assert deleted == 2
     assert delete_stub.calls[0]["op"] == "delete"
+
+    clear_registry()
+
+
+@pytest.mark.asyncio
+async def test_update_validates_enum_values() -> None:
+    clear_registry()
+
+    class Status(Enum):
+        DRAFT = "draft"
+        PUBLISHED = "published"
+
+    meta = type("Meta", (), {"is_table": True})
+    Post = type(
+        "EnumUpdatePost",
+        (Model,),
+        {
+            "__module__": __name__,
+            "__annotations__": {
+                "id": int | None,
+                "status": Status,
+                "status_tags": list[Status] | None,
+                "Meta": ClassVar[type],
+            },
+            "id": Field(default=None, db_pk=True),
+            "status": Field(default=Status.DRAFT),
+            "status_tags": Field(default=None, db_nullable=True),
+            "Meta": meta,
+        },
+    )
+
+    valid_stub = StubExecuteClient([{"affected": 1}])
+    result = await Post.objects.filter(id=1).update(
+        status="published",
+        status_tags=["draft", "published"],
+        client=valid_stub,
+    )
+
+    assert result == 1
+    assert valid_stub.calls[0]["values"]["status"] == "published"
+    assert valid_stub.calls[0]["values"]["status_tags"] == ["draft", "published"]
+
+    null_stub = StubExecuteClient([{"affected": 1}])
+    result = await Post.objects.filter(id=1).update(
+        status_tags=None,
+        client=null_stub,
+    )
+    assert result == 1
+    assert null_stub.calls[0]["values"]["status_tags"] is None
+
+    invalid_stub = StubExecuteClient([{"affected": 1}])
+    with pytest.raises(ValidationError):
+        await Post.objects.filter(id=1).update(
+            status="deleted",
+            client=invalid_stub,
+        )
+    assert invalid_stub.calls == []
+
+    invalid_list_stub = StubExecuteClient([{"affected": 1}])
+    with pytest.raises(ValidationError):
+        await Post.objects.filter(id=1).update(
+            status_tags=["draft", "deleted"],
+            client=invalid_list_stub,
+        )
+    assert invalid_list_stub.calls == []
 
     clear_registry()
 

--- a/python/oxyde/tests/unit/test_type_binding.py
+++ b/python/oxyde/tests/unit/test_type_binding.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from enum import Enum
 from uuid import UUID
 
 import pytest
@@ -33,6 +34,11 @@ U = UUID("550e8400-e29b-41d4-a716-446655440000")
 DEC = Decimal("99.99")
 
 
+class Status(Enum):
+    DRAFT = "draft"
+    PUBLISHED = "published"
+
+
 # -- Model covering all supported types --
 
 
@@ -56,6 +62,8 @@ class TypeModel(Model):
     decimal_tags: list[Decimal] | None = Field(
         default=None, db_nullable=True, max_digits=10, decimal_places=2
     )
+    status: Status = Field(default=Status.DRAFT)
+    status_tags: list[Status] | None = Field(default=None, db_nullable=True)
 
     class Meta:
         is_table = True
@@ -82,6 +90,7 @@ FILTER_CASES = [
     ("decimal", {"price": DEC}, [("Decimal", str(DEC))]),
     ("bytes", {"blob": b"hello"}, [("Bytes", b"hello")]),
     ("dict_json", {"data": {"key": "val"}}, [("Json", '{"key":"val"}')]),
+    ("enum", {"status": Status.DRAFT}, [("String", "draft")]),
     (
         "list_str_array",
         {"tags": ["a", "b"]},
@@ -101,6 +110,11 @@ FILTER_CASES = [
         "list_decimal_array",
         {"decimal_tags": [DEC]},
         [("Array", ("Decimal", [str(DEC)]))],
+    ),
+    (
+        "list_enum_array",
+        {"status_tags": [Status.DRAFT, Status.PUBLISHED]},
+        [("Array", ("String", ["draft", "published"]))],
     ),
 ]
 
@@ -223,6 +237,12 @@ def test_without_types_returns_plain_values():
     assert params == [25, "Alice"]
     assert isinstance(params[0], int)
     assert isinstance(params[1], str)
+
+
+def test_postgres_enum_filter_casts_parameter():
+    sql, params = TypeModel.objects.filter(status=Status.DRAFT).sql(dialect="postgres")
+    assert '$1::"status_enum"' in sql
+    assert params == ["draft"]
 
 
 # ---- count() / exists() use to_ir() and inherit column_types ----

--- a/python/oxyde/tests/unit/test_type_binding.py
+++ b/python/oxyde/tests/unit/test_type_binding.py
@@ -18,6 +18,7 @@ from oxyde._msgpack import msgpack
 from oxyde.core import ir
 from oxyde.core.wrapper import render_sql_debug
 from oxyde.db.pool import _msgpack_encoder
+from oxyde.models.registry import clear_registry
 from oxyde.queries import F
 from oxyde.queries.base import _build_column_types, _model_key
 from oxyde.queries.expressions import _serialize_value_for_ir
@@ -64,6 +65,9 @@ class TypeModel(Model):
     )
     status: Status = Field(default=Status.DRAFT)
     status_tags: list[Status] | None = Field(default=None, db_nullable=True)
+    custom_status_tags: list[Status] | None = Field(
+        default=None, db_nullable=True, db_type="post_status_enum[]"
+    )
 
     class Meta:
         is_table = True
@@ -243,6 +247,52 @@ def test_postgres_enum_filter_casts_parameter():
     sql, params = TypeModel.objects.filter(status=Status.DRAFT).sql(dialect="postgres")
     assert '$1::"status_enum"' in sql
     assert params == ["draft"]
+
+
+def test_postgres_custom_enum_array_filter_casts_parameter():
+    sql, params = TypeModel.objects.filter(
+        custom_status_tags=[Status.DRAFT],
+    ).sql(dialect="postgres", with_types=True)
+
+    assert '$1::"post_status_enum"[]' in sql
+    assert params == [("Array", ("String", ["draft"]))]
+
+
+def test_joined_enum_filter_and_result_columns_are_typed():
+    clear_registry()
+
+    class Author(Model):
+        id: int | None = Field(default=None, db_pk=True)
+        status: Status = Field(default=Status.DRAFT)
+
+        class Meta:
+            is_table = True
+            table_name = "authors"
+
+    class Post(Model):
+        id: int | None = Field(default=None, db_pk=True)
+        author: Author | None = Field(default=None)
+
+        class Meta:
+            is_table = True
+            table_name = "posts"
+
+    query = Post.objects.filter(author__status=Status.DRAFT)
+    query_ir = query.query()
+    enum_spec = {
+        "kind": "enum",
+        "name": "status_enum",
+        "values": ["draft", "published"],
+    }
+
+    assert query_ir["column_types"]["author.status"] == enum_spec
+    assert query_ir["column_types"]["author__status"] == enum_spec
+
+    sql, params = query.sql(dialect="postgres")
+    assert '$1::"status_enum"' in sql
+    assert params == ["draft"]
+
+    clear_registry()
 
 
 # ---- count() / exists() use to_ir() and inherit column_types ----


### PR DESCRIPTION
## Summary

This adds first-class support for string-valued Python enums across schema extraction, migrations, SQL rendering, and runtime value handling.

The migration layer now manages PostgreSQL enum types directly: it creates enum types before dependent tables, appends new enum values with ALTER TYPE, drops unused enum types, and emits a manual migration marker for destructive enum changes such as value removal or reorder. That keeps migration generation usable while making the unsafe step explicit in the generated file.

The query layer now keeps enum values typed as strings for binding, but adds PostgreSQL casts for enum columns and enum arrays. SQLite remains text-backed, while MySQL uses inline ENUM definitions in generated DDL.

## Details

- Detect string-valued Python Enum annotations, including optional fields and list enum arrays.
- Support custom PostgreSQL enum type names through db_type, while preserving text overrides such as TEXT.
- Serialize enum defaults and mutation values through their string values.
- Add PostgreSQL enum casts for filters, IN lookups, inserts, updates, bulk paths, and enum arrays.
- Generate PostgreSQL CREATE TYPE, DROP TYPE, and ALTER TYPE ADD VALUE statements.
- Generate MySQL inline ENUM column definitions and append-value ALTER TABLE statements.
- Replay enum value changes so future migrations see the correct schema state.
- Add validation for enum values passed to update calls before building query IR.

## Testing

- cargo fmt --all --check
- cargo test -p oxyde-codec -p oxyde-query -p oxyde-migrate -p oxyde-driver
- maturin develop
- python -m pytest python/oxyde/tests/unit
- python -m pytest python/oxyde/tests/smoke python/oxyde/tests/integration
- python -m ruff check on changed Python files
- Manual end-to-end checks for migration generation and replay, SQLite enum CRUD, and dialect SQL rendering